### PR TITLE
Migrates to v3 endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openfeature/web-sdk": "^1.2.0",
-        "axios": "^1.7.2",
+        "@openfeature/web-sdk": "^1.3.2",
+        "axios": "^1.7.4",
         "axios-retry": "^4.4.0"
       },
       "devDependencies": {
@@ -1167,17 +1167,17 @@
       }
     },
     "node_modules/@openfeature/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-JyIiije5f+8Big1xz7UAmxqVmHBuFUI9Dh8DEFG2D1ocgjMm1tEzYXJDr3urCQGNnX9M/cYtNhEcGfyontIgJw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-dRBJjnYhEa6XoF9BNf9sW4sHuXmigfBbbatA5djbRXRBDExrXsMydMpEWQqKYhd7XwdwFatuh2q+UkVbXriUKA==",
       "peer": true
     },
     "node_modules/@openfeature/web-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.2.0.tgz",
-      "integrity": "sha512-s1XNeFGTZkk+iFZx9wYOP/5OHMyYFKwGgw9P4LrF6EX3yNwhxhVSiQ+ZUbwW7pSPJf+A4mnczGDRZepho+yV1Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.3.2.tgz",
+      "integrity": "sha512-DY7JwA4Pakczq/s6em8hsLuCL8xYfKeyzb9F18gM3Eh0OStUxrUsKfDKuAk1h9l810W1hoA1AVmvPSsQDHItxw==",
       "peerDependencies": {
-        "@openfeature/core": "1.2.0"
+        "@openfeature/core": "^1.5.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1668,9 +1668,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@openfeature/web-sdk": "^1.2.0",
-    "axios": "^1.7.2",
+    "@openfeature/web-sdk": "^1.3.2",
+    "axios": "^1.7.4",
     "axios-retry": "^4.4.0"
   },
   "jest-junit": {

--- a/src/octopusFeatureClient.ts
+++ b/src/octopusFeatureClient.ts
@@ -69,11 +69,14 @@ export class OctopusFeatureClient {
 
     async getFeatureManifest(): Promise<V1FeatureToggles | undefined> {
         const config: AxiosRequestConfig = {
-            url: `${this.serverUri}/api/featuretoggles/v2/${this.clientIdentifier}`,
+            url: `${this.serverUri}/api/featuretoggles/v3/`,
             maxContentLength: Infinity,
             maxBodyLength: Infinity,
             method: "GET",
             responseType: "json",
+            headers: {
+                Authorization: `Bearer ${this.clientIdentifier}`,
+            },
         };
 
         const response = await this.axiosInstance.request<V1FeatureToggleEvaluation[]>(config);


### PR DESCRIPTION
As a part of securing feature toggle consumption, client identifiers will soon be issued as JWTs, and a new set of endpoints have been added to OctoToggle to work with the new client identifier format to validate consumers are legitimate before providing access to feature toggle evaluations.

This PR:

- Attaches the configured Client Identifier (now expected to be a JWT) to the Authorization header in the Bearer format for outgoing requests
- Uses the v3 endpoint for retrieving evaluated toggles