### PR TITLE
🧹 Added dependabot and implemented hash pinning for third party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm run test
       name: 'Run the tests'
 
-    - uses: dorny/test-reporter@v1
+    - uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
       if: success() || failure()
       name: Tests report
       with:
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release
         with:
           release-type: node


### PR DESCRIPTION
Added dependabot to check github actions and pinned third party actions, have left the default github and the internal packages.

[sc-105971]

Dependabot will now run weekly for this repo and check the github actions for updates

Also updated dorny/test-reporter to v2, and pinned release

ℹ️ Note: googleapis/release-please-action is now pinned as well, this should have been the version the previous one was using, so double check that it runs as expected.