### PR TITLE
ci: Fix Release Please

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -53,6 +53,7 @@ jobs:
         id: release
         with:
           release-type: node
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v6


### PR DESCRIPTION
# Background

We are trying to release for the first time in a while. The Actions workflows are not running against the Release Please PRs because of the way they are being created. e.g. https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/50

We need to give Release Please a PAT with appropriate permissions.

# Changes

* I have added a repository secret `RELEASE_PLEASE_TOKEN`.
* Passing the `RELEASE_PLEASE_TOKEN` to the Release Please action.