### PR TITLE
fix: patch transitive axios vulnerability via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@openfeature/web-sdk": "1.5.0",
-                "axios": "1.15.0",
+                "axios": "^1.16.0",
                 "axios-retry": "4.5.0",
                 "murmurhash3js-revisited": "3.0.0"
             },
@@ -1611,13 +1611,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -2637,9 +2637,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@openfeature/web-sdk": "1.5.0",
-        "axios": "1.15.0",
+        "axios": "^1.16.0",
         "axios-retry": "4.5.0",
         "murmurhash3js-revisited": "3.0.0"
     },


### PR DESCRIPTION
## Addresses axios security alerts:
· High [Axios: Header Injection via Prototype Pollution - #37 - OctopusDeploy/openfeature-provider-ts-web](https://github.com/OctopusDeploy/openfeature-provider-ts-web/security/dependabot/37) 
· High [Axios: Header Injection via Prototype Pollution - #36 - OctopusDeploy/openfeature-provider-ts-web](https://github.com/OctopusDeploy/openfeature-provider-ts-web/security/dependabot/36) 
· High [Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking - #40 - OctopusDeploy/openfeature-provider-ts-web](https://github.com/OctopusDeploy/openfeature-provider-ts-web/security/dependabot/40)
· High [Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking - #41 - OctopusDeploy/openfeature-provider-ts-web](https://github.com/OctopusDeploy/openfeature-provider-ts-web/security/dependabot/41)