### PR TITLE
chore: Fix Release Please tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
     "packages": {
         ".": {
             "release-type": "node",
+            "include-component-in-tag": false,
             "extra-files": ["src/version.ts"]
         }
     }


### PR DESCRIPTION
# Background

The Release Please configuration was changed in https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/62 in order to update the `version.ts` file for use in code.

The new configuration now picks up the package name as part of the release name and tag. i.e. `openfeature-v3.0.2`

# Change

Added [`include-component-in-tag`](https://github.com/googleapis/release-please/blob/v17.6.1/schemas/config.json#L85-L88) configuration item.