### PR TITLE
fix: Remove slug formatting check from flag evaluation

### DIFF
--- a/src/octopusFeatureContext.ts
+++ b/src/octopusFeatureContext.ts
@@ -23,14 +23,6 @@ export class OctopusFeatureContext {
     }
 
     evaluate(slug: string, defaultValue: boolean, context: EvaluationContext): ResolutionDetails<boolean> {
-        if (!slug.match(/^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)$/g)) {
-            return {
-                value: defaultValue,
-                errorCode: ErrorCode.FLAG_NOT_FOUND,
-                errorMessage: "Flag key provided was not a slug. Please ensure to provide the slug associated with your Octopus Feature Toggle.",
-            };
-        }
-
         const evaluation = this.toggles.evaluations.find((feature) => feature.slug.toLowerCase() === slug.toLowerCase());
 
         if (!evaluation) {


### PR DESCRIPTION
## Background 🌇

At the moment when a wrongly formatted slug is submitted for evaluation by the TS provider, we catch it before attempting to look up the toggle in the manifest, and return a FLAG_NOT_FOUND error with a message about invalid formatting. 

## What's this? 🐦 

This change removes the formatting check and falls back to just checking for the wrongly formatted slug like we would for any other slug. If the slug doesn't match any slug in the manifest, regardless of formatting, our existing code paths return a FLAG_NOT_FOUND with an error message that the slug could not be matched. 

This is consistent with [a change made to the .NET provider as part of this ticket](https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/57), and brings the TS code in line with the Java provider which already did not contain the formatting check. 

## Testing 🧪 

✅ This has been tested manually with some correctly and incorrectly formatted slugs. 
✅ The existing `When flag key provided is not a slug` test [here](https://github.com/OctopusDeploy/openfeature-provider-ts-web/blob/main/src/octopusFeatureContext.test.ts#L59) still passes. 

## How to review? 🔍 
❔ Anything I've missed

Part of DEVEX-255