### PR TITLE
fix: Throw OpenFeature errors for unsupported flag types

### DIFF
--- a/src/octopusFeatureContext.ts
+++ b/src/octopusFeatureContext.ts
@@ -22,8 +22,12 @@ export class OctopusFeatureContext {
         this.toggles = toggles;
     }
 
+    findToggleBySlug(slug: string): V2FeatureToggleEvaluation | undefined {
+        return this.toggles.evaluations.find((feature) => feature.slug.toLowerCase() === slug.toLowerCase());
+    }
+
     evaluate(slug: string, defaultValue: boolean, context: EvaluationContext): ResolutionDetails<boolean> {
-        const evaluation = this.toggles.evaluations.find((feature) => feature.slug.toLowerCase() === slug.toLowerCase());
+        const evaluation = this.findToggleBySlug(slug);
 
         if (!evaluation) {
             return {

--- a/src/octopusFeatureProvider.test.ts
+++ b/src/octopusFeatureProvider.test.ts
@@ -101,6 +101,7 @@ describe("Context is available for segment evaluation immediately after provider
 
 describe("Flag type errors are surfaced correctly", () => {
     beforeEach(async () => {
+        await OpenFeature.setContext({});
         jest.mocked(OctopusFeatureClient).mockClear();
         jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest.fn().mockResolvedValue(
             new OctopusFeatureContext({

--- a/src/octopusFeatureProvider.test.ts
+++ b/src/octopusFeatureProvider.test.ts
@@ -1,6 +1,7 @@
 import { OctopusFeatureProvider } from "./octopusFeatureProvider";
 import { ProductMetadata } from "./productMetadata";
 import { OpenFeature } from "@openfeature/web-sdk";
+import { ErrorCode } from "@openfeature/core";
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
 
@@ -95,5 +96,58 @@ describe("Context is available for segment evaluation immediately after provider
 
         const resultAfterContext = OpenFeature.getClient().getBooleanValue("segmented-feature", false);
         expect(resultAfterContext).toBe(true);
+    });
+});
+
+describe("Flag type errors are surfaced correctly", () => {
+    beforeEach(async () => {
+        jest.mocked(OctopusFeatureClient).mockClear();
+        jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest.fn().mockResolvedValue(
+            new OctopusFeatureContext({
+                evaluations: [
+                    {
+                        slug: "feature-a",
+                        isEnabled: true,
+                        evaluationKey: "key",
+                        segments: [],
+                        clientRolloutPercentage: 100,
+                    },
+                ],
+                contentHash: "",
+            })
+        );
+        const provider = new OctopusFeatureProvider({
+            clientIdentifier: "test",
+            productMetadata: new ProductMetadata("TestClient"),
+        });
+        await OpenFeature.setProviderAndWait(provider);
+    });
+
+    afterEach(async () => {
+        await OpenFeature.clearProviders();
+    });
+
+    test("givenAKnownFlag_whenRequestedAsString_returnsTypeMismatch", () => {
+        expect(OpenFeature.getClient().getStringDetails("feature-a", "default").errorCode).toBe(ErrorCode.TYPE_MISMATCH);
+    });
+
+    test("givenAnUnknownFlag_whenRequestedAsString_returnsFlagNotFound", () => {
+        expect(OpenFeature.getClient().getStringDetails("nonexistent", "default").errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+    });
+
+    test("givenAKnownFlag_whenRequestedAsNumber_returnsTypeMismatch", () => {
+        expect(OpenFeature.getClient().getNumberDetails("feature-a", 0).errorCode).toBe(ErrorCode.TYPE_MISMATCH);
+    });
+
+    test("givenAnUnknownFlag_whenRequestedAsNumber_returnsFlagNotFound", () => {
+        expect(OpenFeature.getClient().getNumberDetails("nonexistent", 0).errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+    });
+
+    test("givenAKnownFlag_whenRequestedAsObject_returnsTypeMismatch", () => {
+        expect(OpenFeature.getClient().getObjectDetails("feature-a", {}).errorCode).toBe(ErrorCode.TYPE_MISMATCH);
+    });
+
+    test("givenAnUnknownFlag_whenRequestedAsObject_returnsFlagNotFound", () => {
+        expect(OpenFeature.getClient().getObjectDetails("nonexistent", {}).errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
     });
 });

--- a/src/octopusFeatureProvider.ts
+++ b/src/octopusFeatureProvider.ts
@@ -70,6 +70,6 @@ export class OctopusFeatureProvider implements Provider {
         if (!this.evaluationContext.findToggleBySlug(flagKey)) {
             throw new FlagNotFoundError(flagKey);
         }
-        throw new TypeMismatchError("Octopus Feature Toggles only supports boolean toggles.");
+        throw new TypeMismatchError("Octopus only supports boolean flags.");
     }
 }

--- a/src/octopusFeatureProvider.ts
+++ b/src/octopusFeatureProvider.ts
@@ -1,4 +1,5 @@
 import { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from "@openfeature/web-sdk";
+import { FlagNotFoundError, TypeMismatchError } from "@openfeature/core";
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
 import { ProductMetadata } from "./productMetadata";
@@ -54,14 +55,21 @@ export class OctopusFeatureProvider implements Provider {
     }
 
     resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string> {
-        throw new Error("Octopus Features only support boolean toggles.");
+        return this.rejectNonBooleanEvaluation(flagKey);
     }
 
     resolveNumberEvaluation(flagKey: string, defaultValue: number): ResolutionDetails<number> {
-        throw new Error("Octopus Features only support boolean toggles.");
+        return this.rejectNonBooleanEvaluation(flagKey);
     }
 
     resolveObjectEvaluation<U extends JsonValue>(flagKey: string, defaultValue: U): ResolutionDetails<U> {
-        throw new Error("Octopus Features only support boolean toggles.");
+        return this.rejectNonBooleanEvaluation(flagKey);
+    }
+
+    private rejectNonBooleanEvaluation(flagKey: string): never {
+        if (!this.evaluationContext.findToggleBySlug(flagKey)) {
+            throw new FlagNotFoundError(flagKey);
+        }
+        throw new TypeMismatchError("Octopus Feature Toggles only supports boolean toggles.");
     }
 }


### PR DESCRIPTION
## Background 🌇

At present, OctoToggle only supports boolean type feature flags, but the OpenFeature SDK also allows string, number, and object type feature flags. Currently when we attempt to resolve a non-boolean value, we throw a plain Error, however OpenFeature provides us with [typed error classes](https://openfeature.dev/specification/types/#error-code) which would give a more informative response.

## What's this? 🐦

This PR adjusts each of our functions which resolve a non-boolean feature flag to throw a typed OpenFeature error, which the SDK catches and surfaces as the appropriate error code in ResolutionDetails:

- FLAG_NOT_FOUND - in cases where the slug cannot be matched with any existing toggles
- TYPE_MISMATCH - in cases where a correct slug is provided

As part of this, I've extracted the slug lookup in OctopusFeatureContext into a `findToggleBySlug` method so it can be shared with OctopusFeatureProvider.

## Testing 🧪

✅ Tested manually for both the Function App and ASP.NET implementations - both error types are throwing correctly and valid slugs can still be evaluated for.
✅ Unit tested via the OpenFeature client with the tests included in this PR.

Considering that these error messages are not core functionality, unit tests are fine for now. We also considered [adding specifications tests](https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/56). However this would have required a separate schema and test class for the non-boolean cases, potentially causing us problems later if we're adding other flag types. 

## How to review? 🔍
💬 Check the comments on the code

Part of DEVEX-255

BEGIN_COMMIT_OVERRIDE
fix!: Throw OpenFeature errors for unsupported flag types
END_COMMIT_OVERRIDE