### PR TITLE
ci: setup renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,27 @@
+name: Renovate update dependencies
+on:
+  schedule:
+    # UTC 10:00 PM Sunday - Thursday (AEST 8:00 AM, Monday - Friday)
+    - cron: "0 22 * * 0-4"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Renovate
+        uses: renovatebot/github-action@b50d2ba2bd928235abdcc14d06dfafc217f1c565 # v46.1.18
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || null }}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -12,21 +12,26 @@ module.exports = {
 
   // Raise PRs for known vulnerabilities (replaces Dependabot security alerts).
   osvVulnerabilityAlerts: true,
-
-  // We don't want to pick up third party dependencies the instant they arrive,
-  // to give some time for any issues to be discovered, but not wait too long either.
   minimumReleaseAge: "2 days",
 
   // Match the conventional-commit style used by release-please in this repo.
+  // Runtime dependencies default to `fix` so they trigger a patch release.
   semanticCommits: "enabled",
   semanticCommitType: "fix",
   semanticCommitScope: "deps",
 
   extends: [
     "config:recommended",
-    ":automergeMinor",
     "helpers:pinGitHubActionDigests", // Pin all GitHub Actions to a commit SHA.
   ],
 
   enabledManagers: ["npm", "github-actions"],
+
+  packageRules: [
+    {
+      // Dev-time dependencies don't ship in the published package.
+      matchDepTypes: ["devDependencies"],
+      semanticCommitType: "chore",
+    },
+  ],
 };

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,32 @@
+module.exports = {
+  platform: "github",
+  timezone: "Australia/Brisbane",
+  requireConfig: "optional",
+  onboarding: false,
+
+  repositories: ["OctopusDeploy/openfeature-provider-ts-web"],
+  reviewers: ["team:team-devex"],
+  branchPrefix: "renovate/",
+  labels: ["dependencies"],
+  prConcurrentLimit: 5,
+
+  // Raise PRs for known vulnerabilities (replaces Dependabot security alerts).
+  osvVulnerabilityAlerts: true,
+
+  // We don't want to pick up third party dependencies the instant they arrive,
+  // to give some time for any issues to be discovered, but not wait too long either.
+  minimumReleaseAge: "2 days",
+
+  // Match the conventional-commit style used by release-please in this repo.
+  semanticCommits: "enabled",
+  semanticCommitType: "fix",
+  semanticCommitScope: "deps",
+
+  extends: [
+    "config:recommended",
+    ":automergeMinor",
+    "helpers:pinGitHubActionDigests", // Pin all GitHub Actions to a commit SHA.
+  ],
+
+  enabledManagers: ["npm", "github-actions"],
+};


### PR DESCRIPTION
## Background
Based on [BMBB-475](https://linear.app/octopus/issue/BMBB-475/set-up-renovate-for-openfeature-provider-ts-web) and [BMBB-499](https://linear.app/octopus/issue/BMBB-499/set-minimum-release-age-for-dependencies-in-openfeature-provider-ts), set up Renovate to keep dependencies up to date, and set the minimum release age to 2 days.

## Changes
- Add `.github/workflows/renovate.yml` and `renovate-config.js` to setup renovate as cron job
- Remove `.github/dependabot.yml`: covered by renovate now

## TODO
- [ ] setup `RENOVATE_GIHUB_TOKEN` and testing