### PR TITLE
ci: exempt pin and digest updates from minimumReleaseAge

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -33,5 +33,16 @@ module.exports = {
       matchDepTypes: ["devDependencies"],
       semanticCommitType: "chore",
     },
+    {
+      // pin/pinDigest/digest updates have no release timestamp, so
+      // minimumReleaseAge can never be satisfied and its stability check
+      // would leave those PRs pending forever.
+      // https://github.com/renovatebot/renovate/issues/40288
+      matchUpdateTypes: ['pin', 'pinDigest', 'digest'],
+      minimumReleaseAge: null,
+      prBodyNotes: [
+        '**Manual supply-chain check:** `minimumReleaseAge` cannot be enforced for pin/digest updates because they have no release timestamp. Before merging, confirm this commit SHA has been published for at least **2 days**.',
+      ],
+    },
   ],
 };


### PR DESCRIPTION
minimumReleaseAge can't be satisfied for pin/digest updates (no release timestamp), so those PRs stay pending indefinitely. Exempt those update types from the check.

Contributes to BMBB-499