### PR TITLE
ci: Release OpenFeature bumps as feat

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -20,7 +20,7 @@ module.exports = {
   semanticCommitType: "fix",
   semanticCommitScope: "deps",
 
-  extends: [
+  globalExtends: [
     "config:recommended",
     "helpers:pinGitHubActionDigests", // Pin all GitHub Actions to a commit SHA.
   ],

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -29,6 +29,12 @@ module.exports = {
 
   packageRules: [
     {
+      // OpenFeature SDK updates are worth releasing as a minor version, even if not breaking
+      matchPackageNames: ["@openfeature/web-sdk"],
+      matchUpdateTypes: ["minor", "patch"],
+      semanticCommitType: "feat",
+    },
+    {
       // Dev-time dependencies don't ship in the published package.
       matchDepTypes: ["devDependencies"],
       semanticCommitType: "chore",


### PR DESCRIPTION
# Background

When we update our OpenFeature SDK dependency, while it is not an actual breaking change, we may be causing friction to our consumers that have a direct reference to the SDK, rather than relying on a transitive dependency.

# Changes

Going forward we will mark these upgrades as `feat` commits so that Release Please will bump the minor version of our provider library.

# Notes for review
* This is the equivalent of https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/73 plus https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/82.