### PR TITLE
chore: resolve lint errors and ignore renovate config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         es6: true,
     },
     extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
-    ignorePatterns: ["node_modules/", ".eslintrc.js", "dist/", "jest.config.js"],
+    ignorePatterns: ["node_modules/", ".eslintrc.js", "dist/", "jest.config.js", "renovate-config.js"],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         project: ["./tsconfig.json"],

--- a/src/octopusFeatureClient.test.ts
+++ b/src/octopusFeatureClient.test.ts
@@ -56,9 +56,7 @@ describe("OctopusFeatureClient", () => {
 
         await client.getEvaluationContext();
 
-        expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(
-            `MyProduct openfeature-provider-ts-web/${PROVIDER_VERSION}`
-        );
+        expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(`MyProduct openfeature-provider-ts-web/${PROVIDER_VERSION}`);
     });
 
     test("Should include X-Octopus-Client header with product name and version", async () => {
@@ -70,9 +68,7 @@ describe("OctopusFeatureClient", () => {
 
         await client.getEvaluationContext();
 
-        expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(
-            `MyProduct/2024.1.0 openfeature-provider-ts-web/${PROVIDER_VERSION}`
-        );
+        expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(`MyProduct/2024.1.0 openfeature-provider-ts-web/${PROVIDER_VERSION}`);
     });
 
     test("Should strip unsupported chars from product name in X-Octopus-Client header", async () => {
@@ -84,8 +80,6 @@ describe("OctopusFeatureClient", () => {
 
         await client.getEvaluationContext();
 
-        expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(
-            `MyProduct openfeature-provider-ts-web/${PROVIDER_VERSION}`
-        );
+        expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(`MyProduct openfeature-provider-ts-web/${PROVIDER_VERSION}`);
     });
 });


### PR DESCRIPTION
I ran `npm run lint` while testing https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/98 (`@typescript-eslint/eslint-plugin` bump) and found some errors. 

Figured I may as well clean them up while I'm here.