### PR TITLE
feat: Add v4 evaluation response types

### DIFF
--- a/src/v4/clientSideRule.test.ts
+++ b/src/v4/clientSideRule.test.ts
@@ -1,0 +1,76 @@
+import { ClientSideRule } from "./clientSideRule";
+import { ContextAttributeIsOneOfCondition } from "./conditions/contextAttributeIsOneOfCondition";
+import { PercentageByContextCondition } from "./conditions/percentageByContextCondition";
+import { parseClientSideRule } from "./parseClientSideRule";
+
+describe("ClientSideRule", () => {
+    test("Deserialises its name and its conditions", () => {
+        const json = `
+            {
+                "name": "Rule 1",
+                "conditions": [
+                    { "type": "percentage-by-context", "percentage": 50 },
+                    { "type": "context-attribute-is-one-of", "key": "user-id", "values": ["1234", "5678"] }
+                ]
+            }
+        `;
+
+        const rule = parseClientSideRule(JSON.parse(json));
+
+        expect(rule).toStrictEqual(
+            new ClientSideRule("Rule 1", [new PercentageByContextCondition(50), new ContextAttributeIsOneOfCondition("user-id", ["1234", "5678"])])
+        );
+    });
+
+    test("Reads an absent name as undefined", () => {
+        const rule = parseClientSideRule(JSON.parse(`{ "conditions": [{ "type": "percentage-by-context", "percentage": 50 }] }`));
+
+        expect(rule?.name).toBeUndefined();
+        expect(rule?.conditions).toHaveLength(1);
+    });
+
+    test("Reads absent conditions as undefined", () => {
+        const rule = parseClientSideRule(JSON.parse(`{ "name": "Rule 1" }`));
+
+        expect(rule?.name).toBe("Rule 1");
+        expect(rule?.conditions).toBeUndefined();
+    });
+
+    test("Reads conditions that are not an array as undefined", () => {
+        const rule = parseClientSideRule(JSON.parse(`{ "name": "Rule 1", "conditions": { "type": "percentage-by-context" } }`));
+
+        expect(rule?.conditions).toBeUndefined();
+    });
+
+    test("Reads a condition that is not an object as a missing condition", () => {
+        const rule = parseClientSideRule(JSON.parse(`{ "name": "Rule 1", "conditions": [null, { "type": "percentage-by-context", "percentage": 50 }] }`));
+
+        expect(rule?.conditions).toEqual([undefined, new PercentageByContextCondition(50)]);
+    });
+
+    test("Preserves empty conditions, which evaluation reports rather than parsing", () => {
+        const rule = parseClientSideRule(JSON.parse(`{ "name": "Rule 1", "conditions": [] }`));
+
+        expect(rule).toStrictEqual(new ClientSideRule("Rule 1", []));
+    });
+
+    test("Ignores properties it does not model", () => {
+        const json = `
+            {
+                "name": "Client-side targeting",
+                "conditions": [{ "type": "context-attribute-is-one-of", "key": "license-type", "values": ["free"] }],
+                "cats": "dogs"
+            }
+        `;
+
+        const rule = parseClientSideRule(JSON.parse(json));
+
+        expect(rule).toStrictEqual(new ClientSideRule("Client-side targeting", [new ContextAttributeIsOneOfCondition("license-type", ["free"])]));
+    });
+
+    test("A rule that is not an object reads as a missing rule", () => {
+        expect(parseClientSideRule(JSON.parse(`null`))).toBeUndefined();
+        expect(parseClientSideRule(JSON.parse(`"Rule 1"`))).toBeUndefined();
+        expect(parseClientSideRule(JSON.parse(`[]`))).toBeUndefined();
+    });
+});

--- a/src/v4/clientSideRule.ts
+++ b/src/v4/clientSideRule.ts
@@ -7,8 +7,6 @@ import { ClientSideCondition } from "./conditions/clientSideCondition";
  * @internal
  */
 export class ClientSideRule {
-    // Declared non-optional, but nothing enforces that on a deserialised payload — evaluation
-    // validates before reading either.
     constructor(
         readonly name: string,
         readonly conditions: readonly ClientSideCondition[]

--- a/src/v4/clientSideRule.ts
+++ b/src/v4/clientSideRule.ts
@@ -1,0 +1,16 @@
+import { ClientSideCondition } from "./conditions/clientSideCondition";
+
+/**
+ * A named rule the provider library still has to evaluate on the client side. The rule matches when
+ * every one of its conditions matches.
+ *
+ * @internal
+ */
+export class ClientSideRule {
+    // Declared non-optional, but nothing enforces that on a deserialised payload — evaluation
+    // validates before reading either.
+    constructor(
+        readonly name: string,
+        readonly conditions: readonly ClientSideCondition[]
+    ) {}
+}

--- a/src/v4/conditions/clientSideCondition.ts
+++ b/src/v4/conditions/clientSideCondition.ts
@@ -1,11 +1,6 @@
 /**
  * Base type for a client-side rule condition, selected from the camelCase `type` discriminator when
- * deserialising a v4 evaluation response. These types model the wire shape only; client-side
- * evaluation is not implemented yet.
- *
- * A discriminator this version of the provider does not recognise — or an absent one — deserialises
- * to {@link UnknownCondition} rather than failing, so a condition type introduced by a newer server
- * degrades safely on an older client.
+ * deserialising a v4 evaluation response.
  *
  * @internal
  */

--- a/src/v4/conditions/clientSideCondition.ts
+++ b/src/v4/conditions/clientSideCondition.ts
@@ -1,0 +1,12 @@
+/**
+ * Base type for a client-side rule condition, selected from the camelCase `type` discriminator when
+ * deserialising a v4 evaluation response. These types model the wire shape only; client-side
+ * evaluation is not implemented yet.
+ *
+ * A discriminator this version of the provider does not recognise — or an absent one — deserialises
+ * to {@link UnknownCondition} rather than failing, so a condition type introduced by a newer server
+ * degrades safely on an older client.
+ *
+ * @internal
+ */
+export abstract class ClientSideCondition {}

--- a/src/v4/conditions/conditionTypeNames.ts
+++ b/src/v4/conditions/conditionTypeNames.ts
@@ -1,0 +1,11 @@
+/**
+ * Discriminator values for the polymorphic v4 client-side conditions. These mirror the values in the
+ * evaluation response, so they must not drift from the server.
+ *
+ * @internal
+ */
+export const ConditionTypeNames = {
+    contextAttributeIsNotOneOf: "context-attribute-is-not-one-of",
+    contextAttributeIsOneOf: "context-attribute-is-one-of",
+    percentageByContext: "percentage-by-context",
+} as const;

--- a/src/v4/conditions/conditionTypeNames.ts
+++ b/src/v4/conditions/conditionTypeNames.ts
@@ -1,6 +1,5 @@
 /**
- * Discriminator values for the polymorphic v4 client-side conditions. These mirror the values in the
- * evaluation response, so they must not drift from the server.
+ * Discriminator values for the polymorphic v4 client-side conditions.
  *
  * @internal
  */

--- a/src/v4/conditions/contextAttributeIsNotOneOfCondition.test.ts
+++ b/src/v4/conditions/contextAttributeIsNotOneOfCondition.test.ts
@@ -1,0 +1,30 @@
+import { ContextAttributeIsNotOneOfCondition } from "./contextAttributeIsNotOneOfCondition";
+import { parseCondition } from "./parseCondition";
+
+describe("ContextAttributeIsNotOneOfCondition", () => {
+    test("Deserialises to its concrete type", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-not-one-of", "key": "region", "values": ["us", "eu"] }`));
+
+        expect(condition).toStrictEqual(new ContextAttributeIsNotOneOfCondition("region", ["us", "eu"]));
+    });
+
+    test("Reads an absent key as undefined", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-not-one-of", "values": ["us"] }`)) as ContextAttributeIsNotOneOfCondition;
+
+        expect(condition).toBeInstanceOf(ContextAttributeIsNotOneOfCondition);
+        expect(condition.key).toBeUndefined();
+    });
+
+    test("Reads absent values as undefined", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-not-one-of", "key": "region" }`)) as ContextAttributeIsNotOneOfCondition;
+
+        expect(condition).toBeInstanceOf(ContextAttributeIsNotOneOfCondition);
+        expect(condition.values).toBeUndefined();
+    });
+
+    test("Ignores properties it does not model, including the discriminator", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-not-one-of", "key": "region", "values": ["au"], "cats": "dogs" }`));
+
+        expect(condition).toStrictEqual(new ContextAttributeIsNotOneOfCondition("region", ["au"]));
+    });
+});

--- a/src/v4/conditions/contextAttributeIsNotOneOfCondition.ts
+++ b/src/v4/conditions/contextAttributeIsNotOneOfCondition.ts
@@ -1,0 +1,17 @@
+import { ClientSideCondition } from "./clientSideCondition";
+
+/**
+ * Matches when the context attribute `key` is not one of `values`.
+ *
+ * @internal
+ */
+export class ContextAttributeIsNotOneOfCondition extends ClientSideCondition {
+    // Declared non-optional, but nothing enforces that on a deserialised payload — evaluation
+    // validates before reading either.
+    constructor(
+        readonly key: string,
+        readonly values: readonly string[]
+    ) {
+        super();
+    }
+}

--- a/src/v4/conditions/contextAttributeIsNotOneOfCondition.ts
+++ b/src/v4/conditions/contextAttributeIsNotOneOfCondition.ts
@@ -6,8 +6,6 @@ import { ClientSideCondition } from "./clientSideCondition";
  * @internal
  */
 export class ContextAttributeIsNotOneOfCondition extends ClientSideCondition {
-    // Declared non-optional, but nothing enforces that on a deserialised payload — evaluation
-    // validates before reading either.
     constructor(
         readonly key: string,
         readonly values: readonly string[]

--- a/src/v4/conditions/contextAttributeIsOneOfCondition.test.ts
+++ b/src/v4/conditions/contextAttributeIsOneOfCondition.test.ts
@@ -40,7 +40,7 @@ describe("ContextAttributeIsOneOfCondition", () => {
         expect(condition.values).toEqual(["1234", undefined]);
     });
 
-    test("Preserves empty values, which evaluation reports rather than parsing", () => {
+    test("Preserves empty values", () => {
         const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "user-id", "values": [] }`));
 
         expect(condition).toStrictEqual(new ContextAttributeIsOneOfCondition("user-id", []));

--- a/src/v4/conditions/contextAttributeIsOneOfCondition.test.ts
+++ b/src/v4/conditions/contextAttributeIsOneOfCondition.test.ts
@@ -1,0 +1,54 @@
+import { ContextAttributeIsOneOfCondition } from "./contextAttributeIsOneOfCondition";
+import { parseCondition } from "./parseCondition";
+
+describe("ContextAttributeIsOneOfCondition", () => {
+    test("Deserialises to its concrete type", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "user-id", "values": ["1234", "5678"] }`));
+
+        expect(condition).toStrictEqual(new ContextAttributeIsOneOfCondition("user-id", ["1234", "5678"]));
+    });
+
+    test("Reads an absent key as undefined", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-one-of", "values": ["1234"] }`)) as ContextAttributeIsOneOfCondition;
+
+        expect(condition).toBeInstanceOf(ContextAttributeIsOneOfCondition);
+        expect(condition.key).toBeUndefined();
+        expect(condition.values).toEqual(["1234"]);
+    });
+
+    test("Reads absent values as undefined", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "user-id" }`)) as ContextAttributeIsOneOfCondition;
+
+        expect(condition).toBeInstanceOf(ContextAttributeIsOneOfCondition);
+        expect(condition.key).toBe("user-id");
+        expect(condition.values).toBeUndefined();
+    });
+
+    test("Reads values that are not an array as undefined", () => {
+        const condition = parseCondition(
+            JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "user-id", "values": "1234" }`)
+        ) as ContextAttributeIsOneOfCondition;
+
+        expect(condition.values).toBeUndefined();
+    });
+
+    test("Reads a value that is not a string as undefined, leaving the rest of the array intact", () => {
+        const condition = parseCondition(
+            JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "user-id", "values": ["1234", 5678] }`)
+        ) as ContextAttributeIsOneOfCondition;
+
+        expect(condition.values).toEqual(["1234", undefined]);
+    });
+
+    test("Preserves empty values, which evaluation reports rather than parsing", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "user-id", "values": [] }`));
+
+        expect(condition).toStrictEqual(new ContextAttributeIsOneOfCondition("user-id", []));
+    });
+
+    test("Ignores properties it does not model, including the discriminator", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "context-attribute-is-one-of", "key": "license-type", "values": ["free"], "more": "data" }`));
+
+        expect(condition).toStrictEqual(new ContextAttributeIsOneOfCondition("license-type", ["free"]));
+    });
+});

--- a/src/v4/conditions/contextAttributeIsOneOfCondition.ts
+++ b/src/v4/conditions/contextAttributeIsOneOfCondition.ts
@@ -1,0 +1,17 @@
+import { ClientSideCondition } from "./clientSideCondition";
+
+/**
+ * Matches when the context attribute `key` is one of `values`.
+ *
+ * @internal
+ */
+export class ContextAttributeIsOneOfCondition extends ClientSideCondition {
+    // Declared non-optional, but nothing enforces that on a deserialised payload — evaluation
+    // validates before reading either.
+    constructor(
+        readonly key: string,
+        readonly values: readonly string[]
+    ) {
+        super();
+    }
+}

--- a/src/v4/conditions/contextAttributeIsOneOfCondition.ts
+++ b/src/v4/conditions/contextAttributeIsOneOfCondition.ts
@@ -6,8 +6,6 @@ import { ClientSideCondition } from "./clientSideCondition";
  * @internal
  */
 export class ContextAttributeIsOneOfCondition extends ClientSideCondition {
-    // Declared non-optional, but nothing enforces that on a deserialised payload — evaluation
-    // validates before reading either.
     constructor(
         readonly key: string,
         readonly values: readonly string[]

--- a/src/v4/conditions/parseCondition.test.ts
+++ b/src/v4/conditions/parseCondition.test.ts
@@ -1,0 +1,47 @@
+import { ContextAttributeIsNotOneOfCondition } from "./contextAttributeIsNotOneOfCondition";
+import { ContextAttributeIsOneOfCondition } from "./contextAttributeIsOneOfCondition";
+import { parseCondition } from "./parseCondition";
+import { PercentageByContextCondition } from "./percentageByContextCondition";
+import { UnknownCondition } from "./unknownCondition";
+
+// Polymorphic deserialisation of a single condition. The concrete types are covered by their own
+// tests; whole responses are covered by serverSideEvaluation.test.ts.
+describe("parseCondition", () => {
+    test("A mixed condition array deserialises each to its concrete type", () => {
+        const json = `
+            [
+                { "type": "percentage-by-context", "percentage": 25 },
+                { "type": "context-attribute-is-one-of", "key": "user-id", "values": ["1234"] },
+                { "type": "context-attribute-is-not-one-of", "key": "region", "values": ["au"] }
+            ]
+        `;
+
+        const conditions = (JSON.parse(json) as unknown[]).map(parseCondition);
+
+        expect(conditions).toHaveLength(3);
+        expect(conditions[0]).toBeInstanceOf(PercentageByContextCondition);
+        expect(conditions[1]).toBeInstanceOf(ContextAttributeIsOneOfCondition);
+        expect(conditions[2]).toBeInstanceOf(ContextAttributeIsNotOneOfCondition);
+    });
+
+    test("An unrecognised type alongside known conditions is preserved without failing the others", () => {
+        const json = `
+            [
+                { "type": "percentage-by-context", "percentage": 50 },
+                { "type": "some-future-condition", "someField": "someValue" }
+            ]
+        `;
+
+        const conditions = (JSON.parse(json) as unknown[]).map(parseCondition);
+
+        expect(conditions[0]).toStrictEqual(new PercentageByContextCondition(50));
+        expect(conditions[1]).toStrictEqual(new UnknownCondition("some-future-condition"));
+    });
+
+    test("A condition that is not an object reads as a missing condition", () => {
+        expect(parseCondition(JSON.parse(`null`))).toBeUndefined();
+        expect(parseCondition(JSON.parse(`"context-attribute-is-one-of"`))).toBeUndefined();
+        expect(parseCondition(JSON.parse(`[]`))).toBeUndefined();
+        expect(parseCondition(undefined)).toBeUndefined();
+    });
+});

--- a/src/v4/conditions/parseCondition.ts
+++ b/src/v4/conditions/parseCondition.ts
@@ -11,9 +11,6 @@ import { UnknownCondition } from "./unknownCondition";
  * unrecognised or absent discriminator produces an {@link UnknownCondition} rather than throwing, so
  * a condition type introduced by a newer server degrades safely on an older client.
  *
- * Returns undefined when the condition is not an object at all, which no server version sends: the
- * rule reports it as a missing condition when it is evaluated.
- *
  * @internal
  */
 export function parseCondition(raw: unknown): ClientSideCondition | undefined {
@@ -37,8 +34,6 @@ export function parseCondition(raw: unknown): ClientSideCondition | undefined {
     }
 }
 
-// An absent `values`, or an element that is not a string, is asserted away to match how the other
-// libraries declare the property. Evaluation validates both before reading it.
 function parseValues(raw: unknown): readonly string[] {
     const values = asArray(raw)?.map((value) => asString(value)!);
     return values as readonly string[];

--- a/src/v4/conditions/parseCondition.ts
+++ b/src/v4/conditions/parseCondition.ts
@@ -1,0 +1,45 @@
+import { asArray, asInteger, asRecord, asString } from "../jsonUtils";
+import { ClientSideCondition } from "./clientSideCondition";
+import { ConditionTypeNames } from "./conditionTypeNames";
+import { ContextAttributeIsNotOneOfCondition } from "./contextAttributeIsNotOneOfCondition";
+import { ContextAttributeIsOneOfCondition } from "./contextAttributeIsOneOfCondition";
+import { PercentageByContextCondition } from "./percentageByContextCondition";
+import { UnknownCondition } from "./unknownCondition";
+
+/**
+ * Selects the concrete {@link ClientSideCondition} from the camelCase `type` discriminator. An
+ * unrecognised or absent discriminator produces an {@link UnknownCondition} rather than throwing, so
+ * a condition type introduced by a newer server degrades safely on an older client.
+ *
+ * Returns undefined when the condition is not an object at all, which no server version sends: the
+ * rule reports it as a missing condition when it is evaluated.
+ *
+ * @internal
+ */
+export function parseCondition(raw: unknown): ClientSideCondition | undefined {
+    const condition = asRecord(raw);
+
+    if (condition === undefined) {
+        return undefined;
+    }
+
+    const type = asString(condition.type);
+
+    switch (type) {
+        case ConditionTypeNames.percentageByContext:
+            return new PercentageByContextCondition(asInteger(condition.percentage));
+        case ConditionTypeNames.contextAttributeIsOneOf:
+            return new ContextAttributeIsOneOfCondition(asString(condition.key)!, parseValues(condition.values));
+        case ConditionTypeNames.contextAttributeIsNotOneOf:
+            return new ContextAttributeIsNotOneOfCondition(asString(condition.key)!, parseValues(condition.values));
+        default:
+            return new UnknownCondition(type);
+    }
+}
+
+// An absent `values`, or an element that is not a string, is asserted away to match how the other
+// libraries declare the property. Evaluation validates both before reading it.
+function parseValues(raw: unknown): readonly string[] {
+    const values = asArray(raw)?.map((value) => asString(value)!);
+    return values as readonly string[];
+}

--- a/src/v4/conditions/percentageByContextCondition.test.ts
+++ b/src/v4/conditions/percentageByContextCondition.test.ts
@@ -1,0 +1,46 @@
+import { parseCondition } from "./parseCondition";
+import { PercentageByContextCondition } from "./percentageByContextCondition";
+
+describe("PercentageByContextCondition", () => {
+    test("Deserialises to its concrete type", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context", "percentage": 50 }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(50));
+    });
+
+    test("Reads an absent percentage as undefined, keeping it distinguishable from an explicit 0", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context" }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(undefined));
+    });
+
+    test("Preserves an explicit percentage of 0", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context", "percentage": 0 }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(0));
+    });
+
+    test("Reads a percentage that is not a number as undefined", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context", "percentage": "fifty" }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(undefined));
+    });
+
+    test("Reads a fractional percentage as undefined, as the wire contract is an integer", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context", "percentage": 50.5 }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(undefined));
+    });
+
+    test("Preserves a percentage outside the range, which evaluation reports rather than parsing", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context", "percentage": 101 }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(101));
+    });
+
+    test("Ignores properties it does not model, including the discriminator", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "percentage-by-context", "percentage": 50, "cats": "dogs" }`));
+
+        expect(condition).toStrictEqual(new PercentageByContextCondition(50));
+    });
+});

--- a/src/v4/conditions/percentageByContextCondition.ts
+++ b/src/v4/conditions/percentageByContextCondition.ts
@@ -8,8 +8,7 @@ import { ClientSideCondition } from "./clientSideCondition";
 export class PercentageByContextCondition extends ClientSideCondition {
     /**
      * @param percentage The rollout percentage, 0–100. Optional so an absent `percentage` stays
-     * distinguishable from an explicit 0, which is a legitimate "nobody". A percentage outside the
-     * range is preserved rather than rejected here; evaluation reports it.
+     * distinguishable from an explicit 0, which is a legitimate "nobody".
      */
     constructor(readonly percentage?: number) {
         super();

--- a/src/v4/conditions/percentageByContextCondition.ts
+++ b/src/v4/conditions/percentageByContextCondition.ts
@@ -1,0 +1,17 @@
+import { ClientSideCondition } from "./clientSideCondition";
+
+/**
+ * Matches when the OpenFeature targeting key falls within the `percentage`% rollout.
+ *
+ * @internal
+ */
+export class PercentageByContextCondition extends ClientSideCondition {
+    /**
+     * @param percentage The rollout percentage, 0–100. Optional so an absent `percentage` stays
+     * distinguishable from an explicit 0, which is a legitimate "nobody". A percentage outside the
+     * range is preserved rather than rejected here; evaluation reports it.
+     */
+    constructor(readonly percentage?: number) {
+        super();
+    }
+}

--- a/src/v4/conditions/unknownCondition.test.ts
+++ b/src/v4/conditions/unknownCondition.test.ts
@@ -1,0 +1,29 @@
+import { parseCondition } from "./parseCondition";
+import { UnknownCondition } from "./unknownCondition";
+
+describe("UnknownCondition", () => {
+    test("An unknown condition type deserialises to UnknownCondition instead of throwing", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "not-a-real-condition", "percentage": 50 }`));
+
+        expect(condition).toStrictEqual(new UnknownCondition("not-a-real-condition"));
+    });
+
+    test("A condition without a type discriminator deserialises to UnknownCondition", () => {
+        const condition = parseCondition(JSON.parse(`{ "percentage": 50 }`));
+
+        expect(condition).toStrictEqual(new UnknownCondition(undefined));
+    });
+
+    test("A discriminator that is not a string deserialises to UnknownCondition without a type", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": 123, "percentage": 50 }`));
+
+        expect(condition).toStrictEqual(new UnknownCondition(undefined));
+    });
+
+    test("Retains the discriminator but not the rest of the payload", () => {
+        const condition = parseCondition(JSON.parse(`{ "type": "not-a-real-condition", "key": "license", "values": ["trial"] }`)) as UnknownCondition;
+
+        expect(condition.type).toBe("not-a-real-condition");
+        expect(Object.keys(condition)).toEqual(["type"]);
+    });
+});

--- a/src/v4/conditions/unknownCondition.ts
+++ b/src/v4/conditions/unknownCondition.ts
@@ -1,0 +1,21 @@
+import { ClientSideCondition } from "./clientSideCondition";
+
+/**
+ * A client-side condition whose `type` discriminator this version of the provider does not
+ * recognise, or which carried no discriminator at all. Rather than failing the whole evaluation
+ * response, an unrecognised condition is preserved as this type. It always evaluates to false, so a
+ * rule containing an unknown condition can never match — a newer server capability is safely treated
+ * as "not met" by an older client.
+ *
+ * The raw payload of an unknown condition is not retained, only its discriminator.
+ *
+ * @internal
+ */
+export class UnknownCondition extends ClientSideCondition {
+    /**
+     * @param type The unrecognised discriminator value, or undefined if none was present.
+     */
+    constructor(readonly type?: string) {
+        super();
+    }
+}

--- a/src/v4/conditions/unknownCondition.ts
+++ b/src/v4/conditions/unknownCondition.ts
@@ -7,8 +7,6 @@ import { ClientSideCondition } from "./clientSideCondition";
  * rule containing an unknown condition can never match — a newer server capability is safely treated
  * as "not met" by an older client.
  *
- * The raw payload of an unknown condition is not retained, only its discriminator.
- *
  * @internal
  */
 export class UnknownCondition extends ClientSideCondition {

--- a/src/v4/jsonUtils.ts
+++ b/src/v4/jsonUtils.ts
@@ -1,0 +1,41 @@
+// Reading values out of a parsed v4 evaluation response.
+//
+// A value of the wrong JSON type reads as absent, so a malformed flag is reported when it is
+// evaluated and costs only itself. The .NET and Java providers instead throw while reading the
+// response, losing every flag in it — a gap in their deserialisers rather than a decision, tracked
+// in BMBB-788.
+
+/** @internal */
+export function asString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+/** @internal */
+export function asBoolean(value: unknown): boolean | undefined {
+    return typeof value === "boolean" ? value : undefined;
+}
+
+/**
+ * The wire contract is an integer, so a fractional number reads as absent rather than rolling out to
+ * a percentage the server cannot have asked for.
+ *
+ * @internal
+ */
+export function asInteger(value: unknown): number | undefined {
+    // Math.floor rather than Number.isInteger, which the ES5 target does not have.
+    return typeof value === "number" && Math.floor(value) === value ? value : undefined;
+}
+
+/** @internal */
+export function asArray(value: unknown): readonly unknown[] | undefined {
+    return Array.isArray(value) ? value : undefined;
+}
+
+/**
+ * An array is an object in JSON, but never a rule or a condition, so it reads as absent here too.
+ *
+ * @internal
+ */
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+    return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}

--- a/src/v4/jsonUtils.ts
+++ b/src/v4/jsonUtils.ts
@@ -1,9 +1,7 @@
 // Reading values out of a parsed v4 evaluation response.
 //
 // A value of the wrong JSON type reads as absent, so a malformed flag is reported when it is
-// evaluated and costs only itself. The .NET and Java providers instead throw while reading the
-// response, losing every flag in it — a gap in their deserialisers rather than a decision, tracked
-// in BMBB-788.
+// evaluated and costs only itself.
 
 /** @internal */
 export function asString(value: unknown): string | undefined {
@@ -15,12 +13,7 @@ export function asBoolean(value: unknown): boolean | undefined {
     return typeof value === "boolean" ? value : undefined;
 }
 
-/**
- * The wire contract is an integer, so a fractional number reads as absent rather than rolling out to
- * a percentage the server cannot have asked for.
- *
- * @internal
- */
+/** @internal */
 export function asInteger(value: unknown): number | undefined {
     // Math.floor rather than Number.isInteger, which the ES5 target does not have.
     return typeof value === "number" && Math.floor(value) === value ? value : undefined;

--- a/src/v4/parseClientSideRule.ts
+++ b/src/v4/parseClientSideRule.ts
@@ -1,0 +1,29 @@
+import { ClientSideRule } from "./clientSideRule";
+import { ClientSideCondition } from "./conditions/clientSideCondition";
+import { parseCondition } from "./conditions/parseCondition";
+import { asArray, asRecord, asString } from "./jsonUtils";
+
+/**
+ * Reads a client-side rule and its polymorphic conditions.
+ *
+ * Returns undefined when the rule is not an object at all, which no server version sends: the flag
+ * reports it as a missing rule when it is evaluated.
+ *
+ * @internal
+ */
+export function parseClientSideRule(raw: unknown): ClientSideRule | undefined {
+    const rule = asRecord(raw);
+
+    if (rule === undefined) {
+        return undefined;
+    }
+
+    return new ClientSideRule(asString(rule.name)!, parseConditions(rule.conditions));
+}
+
+// An absent `conditions`, or an element that is not a condition, is asserted away to match how the
+// other libraries declare the property. Evaluation validates both before reading it.
+function parseConditions(raw: unknown): readonly ClientSideCondition[] {
+    const conditions = asArray(raw)?.map((condition) => parseCondition(condition)!);
+    return conditions as readonly ClientSideCondition[];
+}

--- a/src/v4/parseClientSideRule.ts
+++ b/src/v4/parseClientSideRule.ts
@@ -6,9 +6,6 @@ import { asArray, asRecord, asString } from "./jsonUtils";
 /**
  * Reads a client-side rule and its polymorphic conditions.
  *
- * Returns undefined when the rule is not an object at all, which no server version sends: the flag
- * reports it as a missing rule when it is evaluated.
- *
  * @internal
  */
 export function parseClientSideRule(raw: unknown): ClientSideRule | undefined {
@@ -21,8 +18,6 @@ export function parseClientSideRule(raw: unknown): ClientSideRule | undefined {
     return new ClientSideRule(asString(rule.name)!, parseConditions(rule.conditions));
 }
 
-// An absent `conditions`, or an element that is not a condition, is asserted away to match how the
-// other libraries declare the property. Evaluation validates both before reading it.
 function parseConditions(raw: unknown): readonly ClientSideCondition[] {
     const conditions = asArray(raw)?.map((condition) => parseCondition(condition)!);
     return conditions as readonly ClientSideCondition[];

--- a/src/v4/parseServerSideEvaluation.ts
+++ b/src/v4/parseServerSideEvaluation.ts
@@ -1,0 +1,48 @@
+import { ClientSideRule } from "./clientSideRule";
+import { asArray, asBoolean, asRecord, asString } from "./jsonUtils";
+import { parseClientSideRule } from "./parseClientSideRule";
+import { ServerSideEvaluation } from "./serverSideEvaluation";
+
+/**
+ * Reads the v4 evaluations endpoint's response: an array of flags.
+ *
+ * A response that is not an array holds no flags rather than failing, and a flag that is not an
+ * object is dropped — nothing could look it up, as it has no slug. A flag that is malformed in any
+ * other way is kept and reported when it is evaluated, so it costs only itself.
+ *
+ * @internal
+ */
+export function parseServerSideEvaluations(raw: unknown): readonly ServerSideEvaluation[] {
+    const evaluations = asArray(raw) ?? [];
+
+    return evaluations.map(parseServerSideEvaluation).filter((evaluation): evaluation is ServerSideEvaluation => evaluation !== undefined);
+}
+
+/**
+ * Reads a single flag, in either of the two shapes the endpoint returns.
+ *
+ * Returns undefined when the flag is not an object at all.
+ *
+ * @internal
+ */
+export function parseServerSideEvaluation(raw: unknown): ServerSideEvaluation | undefined {
+    const evaluation = asRecord(raw);
+
+    if (evaluation === undefined) {
+        return undefined;
+    }
+
+    return new ServerSideEvaluation(
+        asString(evaluation.slug)!,
+        asBoolean(evaluation.value),
+        asString(evaluation.reason),
+        asString(evaluation.evaluationKey),
+        parseRules(evaluation.rules)
+    );
+}
+
+// A rule that is not an object is asserted away to match how the other libraries declare the
+// property. Evaluation validates each rule before reading it.
+function parseRules(raw: unknown): readonly ClientSideRule[] | undefined {
+    return asArray(raw)?.map((rule) => parseClientSideRule(rule)!);
+}

--- a/src/v4/parseServerSideEvaluation.ts
+++ b/src/v4/parseServerSideEvaluation.ts
@@ -6,10 +6,6 @@ import { ServerSideEvaluation } from "./serverSideEvaluation";
 /**
  * Reads the v4 evaluations endpoint's response: an array of flags.
  *
- * A response that is not an array holds no flags rather than failing, and a flag that is not an
- * object is dropped — nothing could look it up, as it has no slug. A flag that is malformed in any
- * other way is kept and reported when it is evaluated, so it costs only itself.
- *
  * @internal
  */
 export function parseServerSideEvaluations(raw: unknown): readonly ServerSideEvaluation[] {
@@ -20,8 +16,6 @@ export function parseServerSideEvaluations(raw: unknown): readonly ServerSideEva
 
 /**
  * Reads a single flag, in either of the two shapes the endpoint returns.
- *
- * Returns undefined when the flag is not an object at all.
  *
  * @internal
  */
@@ -41,8 +35,6 @@ export function parseServerSideEvaluation(raw: unknown): ServerSideEvaluation | 
     );
 }
 
-// A rule that is not an object is asserted away to match how the other libraries declare the
-// property. Evaluation validates each rule before reading it.
 function parseRules(raw: unknown): readonly ClientSideRule[] | undefined {
     return asArray(raw)?.map((rule) => parseClientSideRule(rule)!);
 }

--- a/src/v4/serverSideEvaluation.test.ts
+++ b/src/v4/serverSideEvaluation.test.ts
@@ -1,0 +1,202 @@
+import { ClientSideRule } from "./clientSideRule";
+import { ContextAttributeIsOneOfCondition } from "./conditions/contextAttributeIsOneOfCondition";
+import { PercentageByContextCondition } from "./conditions/percentageByContextCondition";
+import { UnknownCondition } from "./conditions/unknownCondition";
+import { parseServerSideEvaluation, parseServerSideEvaluations } from "./parseServerSideEvaluation";
+import { ServerSideEvaluation } from "./serverSideEvaluation";
+
+// Deserialisation of a v4 evaluation response: both flag shapes and the array the endpoint returns.
+// Individual conditions are covered by conditions/parseCondition.test.ts.
+describe("ServerSideEvaluation", () => {
+    test("A server-resolved flag deserialises slug, value and reason", () => {
+        const json = `
+            {
+                "slug": "my-feature",
+                "value": true,
+                "reason": "The flag is enabled for this environment."
+            }
+        `;
+
+        const flag = parseServerSideEvaluation(JSON.parse(json));
+
+        expect(flag).toStrictEqual(new ServerSideEvaluation("my-feature", true, "The flag is enabled for this environment.", undefined, undefined));
+    });
+
+    test("A deferred flag deserialises rules with polymorphic conditions", () => {
+        const json = `
+            {
+                "slug": "my-feature",
+                "evaluationKey": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "rules": [
+                    {
+                        "name": "Rule 1",
+                        "conditions": [
+                            { "type": "percentage-by-context", "percentage": 50 },
+                            { "type": "context-attribute-is-one-of", "key": "user-id", "values": ["1234", "5678"] }
+                        ]
+                    }
+                ]
+            }
+        `;
+
+        const flag = parseServerSideEvaluation(JSON.parse(json));
+
+        expect(flag).toStrictEqual(
+            new ServerSideEvaluation("my-feature", undefined, undefined, "0f8fad5b-d9cb-469f-a165-70867728950e", [
+                new ClientSideRule("Rule 1", [new PercentageByContextCondition(50), new ContextAttributeIsOneOfCondition("user-id", ["1234", "5678"])]),
+            ])
+        );
+    });
+
+    test("An unknown condition alongside known conditions is preserved without failing the response", () => {
+        const json = `
+            {
+                "slug": "my-feature",
+                "evaluationKey": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "rules": [
+                    {
+                        "name": "Rule 1",
+                        "conditions": [
+                            { "type": "percentage-by-context", "percentage": 50 },
+                            { "type": "some-future-condition", "someField": "someValue" }
+                        ]
+                    }
+                ]
+            }
+        `;
+
+        const flag = parseServerSideEvaluation(JSON.parse(json));
+
+        const conditions = flag!.rules![0].conditions;
+        expect(conditions[0]).toStrictEqual(new PercentageByContextCondition(50));
+        expect(conditions[1]).toStrictEqual(new UnknownCondition("some-future-condition"));
+    });
+
+    test("An evaluations response deserialises as an array of flags", () => {
+        const json = `
+            [
+                { "slug": "resolved-feature", "value": false, "reason": "The flag is disabled for this environment." },
+                {
+                    "slug": "deferred-feature",
+                    "evaluationKey": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                    "rules": [
+                        { "name": "Rule 1", "conditions": [ { "type": "percentage-by-context", "percentage": 10 } ] }
+                    ]
+                }
+            ]
+        `;
+
+        const flags = parseServerSideEvaluations(JSON.parse(json));
+
+        expect(flags).toHaveLength(2);
+
+        expect(flags[0].slug).toBe("resolved-feature");
+        expect(flags[0].value).toBe(false);
+        expect(flags[0].rules).toBeUndefined();
+
+        expect(flags[1].slug).toBe("deferred-feature");
+        expect(flags[1].value).toBeUndefined();
+        expect(flags[1].rules).toHaveLength(1);
+        expect(flags[1].rules![0].conditions[0]).toStrictEqual(new PercentageByContextCondition(10));
+    });
+
+    test("A flag without a slug deserialises rather than failing the response", () => {
+        const flag = parseServerSideEvaluation(JSON.parse(`{ "value": true, "reason": "The flag is enabled for this environment." }`));
+
+        expect(flag?.slug).toBeUndefined();
+        expect(flag?.value).toBe(true);
+    });
+
+    test("Every flag deserialises when one of them is missing its slug", () => {
+        const json = `
+            [
+                { "value": true, "reason": "The flag is enabled for this environment." },
+                { "slug": "well-formed-feature", "value": true, "reason": "The flag is enabled for this environment." }
+            ]
+        `;
+
+        const flags = parseServerSideEvaluations(JSON.parse(json));
+
+        expect(flags).toHaveLength(2);
+        expect(flags[0].slug).toBeUndefined();
+        expect(flags[1].slug).toBe("well-formed-feature");
+    });
+
+    test("A flag in both shapes at once is preserved, which evaluation reports rather than parsing", () => {
+        const json = `
+            {
+                "slug": "my-feature",
+                "value": true,
+                "reason": "The flag is enabled for this environment.",
+                "evaluationKey": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "rules": [{ "name": "Beta ring", "conditions": [{ "type": "context-attribute-is-one-of", "key": "ring", "values": ["beta"] }] }]
+            }
+        `;
+
+        const flag = parseServerSideEvaluation(JSON.parse(json));
+
+        expect(flag?.value).toBe(true);
+        expect(flag?.rules).toHaveLength(1);
+    });
+
+    test("A flag in neither shape is preserved, which evaluation reports rather than parsing", () => {
+        const flag = parseServerSideEvaluation(JSON.parse(`{ "slug": "my-feature" }`));
+
+        expect(flag).toStrictEqual(new ServerSideEvaluation("my-feature", undefined, undefined, undefined, undefined));
+    });
+
+    test("A rule that is not an object reads as a missing rule", () => {
+        const json = `
+            {
+                "slug": "my-feature",
+                "evaluationKey": "0f8fad5b-d9cb-469f-a165-70867728950e",
+                "rules": [null, { "name": "Rule 1", "conditions": [{ "type": "percentage-by-context", "percentage": 50 }] }]
+            }
+        `;
+
+        const flag = parseServerSideEvaluation(JSON.parse(json));
+
+        expect(flag?.rules?.[0]).toBeUndefined();
+        expect(flag?.rules?.[1]).toStrictEqual(new ClientSideRule("Rule 1", [new PercentageByContextCondition(50)]));
+    });
+
+    test("Ignores properties it does not model, at every level", () => {
+        const json = `
+            {
+                "slug": "feature-with-extra-fields",
+                "evaluationKey": "evaluation-key",
+                "rules": [
+                    {
+                        "name": "Client-side targeting",
+                        "conditions": [{ "type": "context-attribute-is-one-of", "key": "license-type", "values": ["free"], "more": "data" }],
+                        "cats": "dogs"
+                    }
+                ],
+                "pianos": { "nested": "value" }
+            }
+        `;
+
+        const flag = parseServerSideEvaluation(JSON.parse(json));
+
+        expect(flag).toStrictEqual(
+            new ServerSideEvaluation("feature-with-extra-fields", undefined, undefined, "evaluation-key", [
+                new ClientSideRule("Client-side targeting", [new ContextAttributeIsOneOfCondition("license-type", ["free"])]),
+            ])
+        );
+    });
+
+    test("A flag that is not an object is dropped from the response", () => {
+        const json = `[null, "my-feature", { "slug": "well-formed-feature", "value": true, "reason": "The flag is enabled for this environment." }]`;
+
+        const flags = parseServerSideEvaluations(JSON.parse(json));
+
+        expect(flags).toHaveLength(1);
+        expect(flags[0].slug).toBe("well-formed-feature");
+    });
+
+    test("A response that is not an array holds no flags", () => {
+        expect(parseServerSideEvaluations(JSON.parse(`{ "slug": "my-feature" }`))).toEqual([]);
+        expect(parseServerSideEvaluations(JSON.parse(`null`))).toEqual([]);
+        expect(parseServerSideEvaluations(undefined)).toEqual([]);
+    });
+});

--- a/src/v4/serverSideEvaluation.test.ts
+++ b/src/v4/serverSideEvaluation.test.ts
@@ -5,10 +5,10 @@ import { UnknownCondition } from "./conditions/unknownCondition";
 import { parseServerSideEvaluation, parseServerSideEvaluations } from "./parseServerSideEvaluation";
 import { ServerSideEvaluation } from "./serverSideEvaluation";
 
-// Deserialisation of a v4 evaluation response: both flag shapes and the array the endpoint returns.
+// Deserialisation of a v4 evaluation response: both evaluation shapes and the array the endpoint returns.
 // Individual conditions are covered by conditions/parseCondition.test.ts.
 describe("ServerSideEvaluation", () => {
-    test("A server-resolved flag deserialises slug, value and reason", () => {
+    test("A server-resolved evaluation deserialises slug, value and reason", () => {
         const json = `
             {
                 "slug": "my-feature",
@@ -17,12 +17,12 @@ describe("ServerSideEvaluation", () => {
             }
         `;
 
-        const flag = parseServerSideEvaluation(JSON.parse(json));
+        const evaluation = parseServerSideEvaluation(JSON.parse(json));
 
-        expect(flag).toStrictEqual(new ServerSideEvaluation("my-feature", true, "The flag is enabled for this environment.", undefined, undefined));
+        expect(evaluation).toStrictEqual(new ServerSideEvaluation("my-feature", true, "The flag is enabled for this environment.", undefined, undefined));
     });
 
-    test("A deferred flag deserialises rules with polymorphic conditions", () => {
+    test("A deferred evaluation deserialises rules with polymorphic conditions", () => {
         const json = `
             {
                 "slug": "my-feature",
@@ -39,9 +39,9 @@ describe("ServerSideEvaluation", () => {
             }
         `;
 
-        const flag = parseServerSideEvaluation(JSON.parse(json));
+        const evaluation = parseServerSideEvaluation(JSON.parse(json));
 
-        expect(flag).toStrictEqual(
+        expect(evaluation).toStrictEqual(
             new ServerSideEvaluation("my-feature", undefined, undefined, "0f8fad5b-d9cb-469f-a165-70867728950e", [
                 new ClientSideRule("Rule 1", [new PercentageByContextCondition(50), new ContextAttributeIsOneOfCondition("user-id", ["1234", "5678"])]),
             ])
@@ -65,14 +65,14 @@ describe("ServerSideEvaluation", () => {
             }
         `;
 
-        const flag = parseServerSideEvaluation(JSON.parse(json));
+        const evaluation = parseServerSideEvaluation(JSON.parse(json));
 
-        const conditions = flag!.rules![0].conditions;
+        const conditions = evaluation!.rules![0].conditions;
         expect(conditions[0]).toStrictEqual(new PercentageByContextCondition(50));
         expect(conditions[1]).toStrictEqual(new UnknownCondition("some-future-condition"));
     });
 
-    test("An evaluations response deserialises as an array of flags", () => {
+    test("An evaluation response deserialises as an array of evaluations", () => {
         const json = `
             [
                 { "slug": "resolved-feature", "value": false, "reason": "The flag is disabled for this environment." },
@@ -86,28 +86,28 @@ describe("ServerSideEvaluation", () => {
             ]
         `;
 
-        const flags = parseServerSideEvaluations(JSON.parse(json));
+        const evaluations = parseServerSideEvaluations(JSON.parse(json));
 
-        expect(flags).toHaveLength(2);
+        expect(evaluations).toHaveLength(2);
 
-        expect(flags[0].slug).toBe("resolved-feature");
-        expect(flags[0].value).toBe(false);
-        expect(flags[0].rules).toBeUndefined();
+        expect(evaluations[0].slug).toBe("resolved-feature");
+        expect(evaluations[0].value).toBe(false);
+        expect(evaluations[0].rules).toBeUndefined();
 
-        expect(flags[1].slug).toBe("deferred-feature");
-        expect(flags[1].value).toBeUndefined();
-        expect(flags[1].rules).toHaveLength(1);
-        expect(flags[1].rules![0].conditions[0]).toStrictEqual(new PercentageByContextCondition(10));
+        expect(evaluations[1].slug).toBe("deferred-feature");
+        expect(evaluations[1].value).toBeUndefined();
+        expect(evaluations[1].rules).toHaveLength(1);
+        expect(evaluations[1].rules![0].conditions[0]).toStrictEqual(new PercentageByContextCondition(10));
     });
 
-    test("A flag without a slug deserialises rather than failing the response", () => {
-        const flag = parseServerSideEvaluation(JSON.parse(`{ "value": true, "reason": "The flag is enabled for this environment." }`));
+    test("An evaluation without a slug deserialises rather than failing the response", () => {
+        const evaluation = parseServerSideEvaluation(JSON.parse(`{ "value": true, "reason": "The flag is enabled for this environment." }`));
 
-        expect(flag?.slug).toBeUndefined();
-        expect(flag?.value).toBe(true);
+        expect(evaluation?.slug).toBeUndefined();
+        expect(evaluation?.value).toBe(true);
     });
 
-    test("Every flag deserialises when one of them is missing its slug", () => {
+    test("Every evaluation deserialises when one of them is missing its slug", () => {
         const json = `
             [
                 { "value": true, "reason": "The flag is enabled for this environment." },
@@ -115,14 +115,14 @@ describe("ServerSideEvaluation", () => {
             ]
         `;
 
-        const flags = parseServerSideEvaluations(JSON.parse(json));
+        const evaluations = parseServerSideEvaluations(JSON.parse(json));
 
-        expect(flags).toHaveLength(2);
-        expect(flags[0].slug).toBeUndefined();
-        expect(flags[1].slug).toBe("well-formed-feature");
+        expect(evaluations).toHaveLength(2);
+        expect(evaluations[0].slug).toBeUndefined();
+        expect(evaluations[1].slug).toBe("well-formed-feature");
     });
 
-    test("A flag in both shapes at once is preserved, which evaluation reports rather than parsing", () => {
+    test("An evaluation in both shapes at once is preserved, which evaluation reports rather than parsing", () => {
         const json = `
             {
                 "slug": "my-feature",
@@ -133,16 +133,16 @@ describe("ServerSideEvaluation", () => {
             }
         `;
 
-        const flag = parseServerSideEvaluation(JSON.parse(json));
+        const evaluation = parseServerSideEvaluation(JSON.parse(json));
 
-        expect(flag?.value).toBe(true);
-        expect(flag?.rules).toHaveLength(1);
+        expect(evaluation?.value).toBe(true);
+        expect(evaluation?.rules).toHaveLength(1);
     });
 
-    test("A flag in neither shape is preserved, which evaluation reports rather than parsing", () => {
-        const flag = parseServerSideEvaluation(JSON.parse(`{ "slug": "my-feature" }`));
+    test("An evaluation in neither shape is preserved, which evaluation reports rather than parsing", () => {
+        const evaluation = parseServerSideEvaluation(JSON.parse(`{ "slug": "my-feature" }`));
 
-        expect(flag).toStrictEqual(new ServerSideEvaluation("my-feature", undefined, undefined, undefined, undefined));
+        expect(evaluation).toStrictEqual(new ServerSideEvaluation("my-feature", undefined, undefined, undefined, undefined));
     });
 
     test("A rule that is not an object reads as a missing rule", () => {
@@ -154,10 +154,10 @@ describe("ServerSideEvaluation", () => {
             }
         `;
 
-        const flag = parseServerSideEvaluation(JSON.parse(json));
+        const evaluation = parseServerSideEvaluation(JSON.parse(json));
 
-        expect(flag?.rules?.[0]).toBeUndefined();
-        expect(flag?.rules?.[1]).toStrictEqual(new ClientSideRule("Rule 1", [new PercentageByContextCondition(50)]));
+        expect(evaluation?.rules?.[0]).toBeUndefined();
+        expect(evaluation?.rules?.[1]).toStrictEqual(new ClientSideRule("Rule 1", [new PercentageByContextCondition(50)]));
     });
 
     test("Ignores properties it does not model, at every level", () => {
@@ -176,25 +176,25 @@ describe("ServerSideEvaluation", () => {
             }
         `;
 
-        const flag = parseServerSideEvaluation(JSON.parse(json));
+        const evaluation = parseServerSideEvaluation(JSON.parse(json));
 
-        expect(flag).toStrictEqual(
+        expect(evaluation).toStrictEqual(
             new ServerSideEvaluation("feature-with-extra-fields", undefined, undefined, "evaluation-key", [
                 new ClientSideRule("Client-side targeting", [new ContextAttributeIsOneOfCondition("license-type", ["free"])]),
             ])
         );
     });
 
-    test("A flag that is not an object is dropped from the response", () => {
+    test("An evaluation that is not an object is dropped from the response", () => {
         const json = `[null, "my-feature", { "slug": "well-formed-feature", "value": true, "reason": "The flag is enabled for this environment." }]`;
 
-        const flags = parseServerSideEvaluations(JSON.parse(json));
+        const evaluations = parseServerSideEvaluations(JSON.parse(json));
 
-        expect(flags).toHaveLength(1);
-        expect(flags[0].slug).toBe("well-formed-feature");
+        expect(evaluations).toHaveLength(1);
+        expect(evaluations[0].slug).toBe("well-formed-feature");
     });
 
-    test("A response that is not an array holds no flags", () => {
+    test("A response that is not an array holds no evaluations", () => {
         expect(parseServerSideEvaluations(JSON.parse(`{ "slug": "my-feature" }`))).toEqual([]);
         expect(parseServerSideEvaluations(JSON.parse(`null`))).toEqual([]);
         expect(parseServerSideEvaluations(undefined)).toEqual([]);

--- a/src/v4/serverSideEvaluation.ts
+++ b/src/v4/serverSideEvaluation.ts
@@ -1,0 +1,27 @@
+import { ClientSideRule } from "./clientSideRule";
+
+/**
+ * A single feature flag as returned by the Feature Flags service v4 evaluations endpoint. The
+ * endpoint returns an array of these.
+ *
+ * A flag is returned in one of two shapes:
+ * - Resolved by the server — `value` and `reason` are populated.
+ * - Deferred to the client — `evaluationKey` and `rules` are populated and the provider library must
+ *   evaluate the remaining client-side conditions.
+ *
+ * Properties that do not apply to the returned shape are omitted from the JSON. A flag in neither
+ * shape, or in both, is reported when it is evaluated rather than when it is read.
+ *
+ * @internal
+ */
+export class ServerSideEvaluation {
+    // `slug` is declared non-optional, but nothing enforces that on a deserialised payload —
+    // evaluation validates before reading it.
+    constructor(
+        readonly slug: string,
+        readonly value?: boolean,
+        readonly reason?: string,
+        readonly evaluationKey?: string,
+        readonly rules?: readonly ClientSideRule[]
+    ) {}
+}

--- a/src/v4/serverSideEvaluation.ts
+++ b/src/v4/serverSideEvaluation.ts
@@ -9,14 +9,9 @@ import { ClientSideRule } from "./clientSideRule";
  * - Deferred to the client — `evaluationKey` and `rules` are populated and the provider library must
  *   evaluate the remaining client-side conditions.
  *
- * Properties that do not apply to the returned shape are omitted from the JSON. A flag in neither
- * shape, or in both, is reported when it is evaluated rather than when it is read.
- *
  * @internal
  */
 export class ServerSideEvaluation {
-    // `slug` is declared non-optional, but nothing enforces that on a deserialised payload —
-    // evaluation validates before reading it.
     constructor(
         readonly slug: string,
         readonly value?: boolean,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,6 @@
         "module": "CommonJS",
         "moduleResolution": "node",
         "declaration": true,
-        // Declarations tagged @internal are omitted from the emitted .d.ts files. Tagging a type
-        // removes it from the published API surface, so the tag is not documentation.
         "stripInternal": true,
         "esModuleInterop": true,
         "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
         "module": "CommonJS",
         "moduleResolution": "node",
         "declaration": true,
+        // Declarations tagged @internal are omitted from the emitted .d.ts files. Tagging a type
+        // removes it from the published API surface, so the tag is not documentation.
+        "stripInternal": true,
         "esModuleInterop": true,
         "strict": true,
         "downlevelIteration": true,


### PR DESCRIPTION
# Background

Octopus Feature Flags are moving from a single form-based configuration to rules-based evaluation.

New API endpoints have been added to the Feature Flags service with a v4 designation, including a new evaluations endpoint which returns a different shape of response that v3.

This PR only adds types to represent the new shapes without implementing the client-side evaluation or modifying the existing functionality using v3.

# Changes

* Added new v4 evaluation response types as classes.
  * Types have been marked as `@internal`, which combined with `stripInternal` configuration, means they won't be exposed in `.d.ts` files.
* Added `parseX` functions that take plain JSON objects and return class instances.
  * Silently pass missing values on to be validated during evaluation (in next PR).
  * Silently handle incorrect types by replacing with `undefined` values.

Resolves BMBB-748.

Equivalent to https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/92 and https://github.com/OctopusDeploy/openfeature-provider-java/pull/52.

# Notes for review

* Many of the tests for the types are more accurately tests of their corresponding `parseX` function, but given how entwined they are, I think it makes sense to test them together this way.
* We are holding TypeScript a little strangely in order to maintain parity between the libraries. e.g. TypeScript can more expressively handle potentially missing values (`string | undefined`), but we are instead `!` values that we know very well may be `undefined`. As we move to more languages we may find that trying to keep things completely aligned is more effort than it's worth, but for now we'll press on.