### PR TITLE
feat!: Add support for upcoming rules-based evaluations

### DIFF
--- a/src/equalsIgnoringCase.ts
+++ b/src/equalsIgnoringCase.ts
@@ -1,0 +1,13 @@
+/**
+ * Case-insensitive string equality, shared by slug lookup ({@link OctopusFeatureContext}), condition
+ * attribute/value matching ({@link isOneOf}), and the warn-once key for unrecognised slugs — one fold
+ * so the three can't quietly disagree with each other.
+ *
+ * Stands in for .NET's OrdinalIgnoreCase, which folds with invariant uppercase. The two agree on every
+ * ASCII input; they part on JavaScript's full case mappings, where "ß" uppercases to "SS".
+ *
+ * @internal
+ */
+export function equalsIgnoringCase(left: string, right: string): boolean {
+    return left.toUpperCase() === right.toUpperCase();
+}

--- a/src/equalsIgnoringCase.ts
+++ b/src/equalsIgnoringCase.ts
@@ -1,7 +1,5 @@
 /**
- * Case-insensitive string equality, shared by slug lookup ({@link OctopusFeatureContext}), condition
- * attribute/value matching ({@link isOneOf}), and the warn-once key for unrecognised slugs — one fold
- * so the three can't quietly disagree with each other.
+ * Case-insensitive string equality.
  *
  * Stands in for .NET's OrdinalIgnoreCase, which folds with invariant uppercase. The two agree on every
  * ASCII input; they part on JavaScript's full case mappings, where "ß" uppercases to "SS".

--- a/src/octopusFeatureClient.test.ts
+++ b/src/octopusFeatureClient.test.ts
@@ -1,5 +1,6 @@
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { ProductMetadata } from "./productMetadata";
+import { silentLogger } from "./testing/logger";
 import { PROVIDER_VERSION } from "./version";
 import axios from "axios";
 import axiosRetry from "axios-retry";
@@ -84,6 +85,8 @@ describe("OctopusFeatureClient", () => {
     });
 
     describe("the manifest cache", () => {
+        const mockedLocalStorage = global.localStorage;
+
         beforeEach(() => {
             const store = new Map<string, string>();
             global.localStorage = {
@@ -104,12 +107,31 @@ describe("OctopusFeatureClient", () => {
             };
         });
 
+        // The store above stands in for the jest-localstorage-mock global, which resetMocks strips of its
+        // implementation before every test. Put it back so nothing added after this block inherits it.
+        afterEach(() => {
+            global.localStorage = mockedLocalStorage;
+        });
+
         function newClient(): OctopusFeatureClient {
-            return new OctopusFeatureClient({ clientIdentifier: "a.b.c", productMetadata: new ProductMetadata("TestClient") });
+            return new OctopusFeatureClient({ clientIdentifier: "a.b.c", productMetadata: new ProductMetadata("TestClient"), logger: silentLogger() });
         }
 
         function cachedManifest(): unknown {
             return JSON.parse(localStorage.getItem("octopus-openfeature-ts-feature-manifest")!);
+        }
+
+        function cacheEvaluationFor(slug: string): void {
+            localStorage.setItem(
+                "octopus-openfeature-ts-feature-manifest",
+                JSON.stringify({
+                    schemaVersion: "v3",
+                    contents: {
+                        evaluations: [{ slug, value: true, reason: "The flag is enabled for this environment." }],
+                        contentHash: "cached-hash",
+                    },
+                })
+            );
         }
 
         test("Writes a v3 cache entry after a successful fetch", async () => {
@@ -135,23 +157,57 @@ describe("OctopusFeatureClient", () => {
             expect(context.evaluate("my-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
         });
 
-        test("Falls back to a cached v3 entry when the fetch does not return a manifest", async () => {
-            // No ContentHash header, so getFeatureManifest() reports no manifest without retrying.
+        test("Falls back to a cached v3 entry when the response has no ContentHash header", async () => {
             mockAdapter.onGet().reply(200, []);
-            localStorage.setItem(
-                "octopus-openfeature-ts-feature-manifest",
-                JSON.stringify({
-                    schemaVersion: "v3",
-                    contents: {
-                        evaluations: [{ slug: "cached-feature", value: true, reason: "The flag is enabled for this environment." }],
-                        contentHash: "cached-hash",
-                    },
-                })
-            );
+            cacheEvaluationFor("cached-feature");
 
             const context = await newClient().getEvaluationContext();
 
             expect(context.evaluate("cached-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
+        });
+
+        test("Falls back to a cached v3 entry when the server cannot be reached", async () => {
+            mockAdapter.onGet().networkError();
+            cacheEvaluationFor("cached-feature");
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.evaluate("cached-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
+        });
+
+        test("Falls back to a cached v3 entry when the flags are not found", async () => {
+            mockAdapter.onGet().reply(404);
+            cacheEvaluationFor("cached-feature");
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.evaluate("cached-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
+        });
+
+        test("Falls back to a cached v3 entry when the server keeps failing", async () => {
+            mockAdapter.onGet().reply(500);
+            cacheEvaluationFor("cached-feature");
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.evaluate("cached-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
+        });
+
+        test("Leaves the cache entry in place when the fetch fails", async () => {
+            mockAdapter.onGet().networkError();
+            cacheEvaluationFor("cached-feature");
+
+            await newClient().getEvaluationContext();
+
+            expect(cachedManifest()).toMatchObject({ schemaVersion: "v3", contents: { contentHash: "cached-hash" } });
+        });
+
+        test("Falls back to an empty context when the fetch fails and there is no cache entry", async () => {
+            mockAdapter.onGet().networkError();
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.findToggleBySlug("anything")).toBeUndefined();
         });
 
         test("Treats a cache entry from a previous schema version as a miss and removes it", async () => {

--- a/src/octopusFeatureClient.test.ts
+++ b/src/octopusFeatureClient.test.ts
@@ -21,8 +21,8 @@ describe("OctopusFeatureClient", () => {
         mockAdapter.reset();
     });
 
-    test("Should invoke the toggles evaluations v3 endpoint", async () => {
-        mockAdapter.onGet().reply(200, {});
+    test("Should invoke the v4 feature flag evaluations endpoint", async () => {
+        mockAdapter.onGet().reply(200, [], { ContentHash: "aGFzaA==" });
         const client = new OctopusFeatureClient({
             clientIdentifier: "a.b.c",
             productMetadata: new ProductMetadata("TestClient"),
@@ -30,12 +30,12 @@ describe("OctopusFeatureClient", () => {
 
         await client.getEvaluationContext();
 
-        expect(mockAdapter.history.get[0].url).toMatch(/\/toggles\/evaluations\/v3\/$/);
+        expect(mockAdapter.history.get[0].url).toMatch(/\/feature-flags\/evaluations\/v4\/$/);
     });
 
     test("Should include releaseVersionOverride in HTTP header if provided in configuration", async () => {
         const releaseVersionOverride = "1.2.3";
-        mockAdapter.onGet().reply(200, {});
+        mockAdapter.onGet().reply(200, [], { ContentHash: "aGFzaA==" });
         const client = new OctopusFeatureClient({
             clientIdentifier: "a.b.c",
             productMetadata: new ProductMetadata("TestClient"),
@@ -48,7 +48,7 @@ describe("OctopusFeatureClient", () => {
     });
 
     test("Should include X-Octopus-Client header with product name only", async () => {
-        mockAdapter.onGet().reply(200, {});
+        mockAdapter.onGet().reply(200, [], { ContentHash: "aGFzaA==" });
         const client = new OctopusFeatureClient({
             clientIdentifier: "a.b.c",
             productMetadata: new ProductMetadata("MyProduct"),
@@ -60,7 +60,7 @@ describe("OctopusFeatureClient", () => {
     });
 
     test("Should include X-Octopus-Client header with product name and version", async () => {
-        mockAdapter.onGet().reply(200, {});
+        mockAdapter.onGet().reply(200, [], { ContentHash: "aGFzaA==" });
         const client = new OctopusFeatureClient({
             clientIdentifier: "a.b.c",
             productMetadata: new ProductMetadata("MyProduct", "2024.1.0"),
@@ -72,7 +72,7 @@ describe("OctopusFeatureClient", () => {
     });
 
     test("Should strip unsupported chars from product name in X-Octopus-Client header", async () => {
-        mockAdapter.onGet().reply(200, {});
+        mockAdapter.onGet().reply(200, [], { ContentHash: "aGFzaA==" });
         const client = new OctopusFeatureClient({
             clientIdentifier: "a.b.c",
             productMetadata: new ProductMetadata("My Product"),
@@ -81,5 +81,110 @@ describe("OctopusFeatureClient", () => {
         await client.getEvaluationContext();
 
         expect(mockAdapter.history.get[0].headers!["X-Octopus-Client"]).toEqual(`MyProduct openfeature-provider-ts-web/${PROVIDER_VERSION}`);
+    });
+
+    describe("the manifest cache", () => {
+        // jest-localstorage-mock's getItem/setItem close over instance state via jest.fn(impl), which
+        // jest.config.js's resetMocks strips before every test. A plain in-memory Storage sidesteps
+        // that entirely, since resetMocks only touches mocks it created.
+        beforeEach(() => {
+            const store = new Map<string, string>();
+            global.localStorage = {
+                getItem: (key) => (store.has(key) ? store.get(key)! : null),
+                setItem: (key, value) => {
+                    store.set(key, String(value));
+                },
+                removeItem: (key) => {
+                    store.delete(key);
+                },
+                clear: () => {
+                    store.clear();
+                },
+                key: (index) => Array.from(store.keys())[index] ?? null,
+                get length() {
+                    return store.size;
+                },
+            };
+        });
+
+        function newClient(): OctopusFeatureClient {
+            return new OctopusFeatureClient({ clientIdentifier: "a.b.c", productMetadata: new ProductMetadata("TestClient") });
+        }
+
+        function cachedManifest(): unknown {
+            return JSON.parse(localStorage.getItem("octopus-openfeature-ts-feature-manifest")!);
+        }
+
+        test("Writes a v3 cache entry after a successful fetch", async () => {
+            mockAdapter.onGet().reply(200, [{ slug: "my-feature", value: true, reason: "The flag is enabled for this environment." }], {
+                ContentHash: "aGFzaA==",
+            });
+
+            await newClient().getEvaluationContext();
+
+            expect(cachedManifest()).toEqual({
+                schemaVersion: "v3",
+                contents: { evaluations: [{ slug: "my-feature", value: true, reason: "The flag is enabled for this environment." }], contentHash: "aGFzaA==" },
+            });
+        });
+
+        test("Evaluates against the flags returned by a successful fetch", async () => {
+            mockAdapter.onGet().reply(200, [{ slug: "my-feature", value: true, reason: "The flag is enabled for this environment." }], {
+                ContentHash: "aGFzaA==",
+            });
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.evaluate("my-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
+        });
+
+        test("Falls back to a cached v3 entry when the fetch does not return a manifest", async () => {
+            // No ContentHash header, so getFeatureManifest() reports no manifest without retrying.
+            mockAdapter.onGet().reply(200, []);
+            localStorage.setItem(
+                "octopus-openfeature-ts-feature-manifest",
+                JSON.stringify({
+                    schemaVersion: "v3",
+                    contents: {
+                        evaluations: [{ slug: "cached-feature", value: true, reason: "The flag is enabled for this environment." }],
+                        contentHash: "cached-hash",
+                    },
+                })
+            );
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.evaluate("cached-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
+        });
+
+        test("Treats a cache entry from a previous schema version as a miss and removes it", async () => {
+            mockAdapter.onGet().reply(200, []);
+            localStorage.setItem(
+                "octopus-openfeature-ts-feature-manifest",
+                JSON.stringify({ schemaVersion: "v2", contents: { evaluations: [], contentHash: "cached-hash" } })
+            );
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.findToggleBySlug("anything")).toBeUndefined();
+            expect(localStorage.getItem("octopus-openfeature-ts-feature-manifest")).toBeNull();
+        });
+
+        test("Falls back to an empty context when there is no cache entry at all", async () => {
+            mockAdapter.onGet().reply(200, []);
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.findToggleBySlug("anything")).toBeUndefined();
+        });
+
+        test("Falls back to an empty context when the cache entry is not valid JSON", async () => {
+            mockAdapter.onGet().reply(200, []);
+            localStorage.setItem("octopus-openfeature-ts-feature-manifest", "not json");
+
+            const context = await newClient().getEvaluationContext();
+
+            expect(context.findToggleBySlug("anything")).toBeUndefined();
+        });
     });
 });

--- a/src/octopusFeatureClient.test.ts
+++ b/src/octopusFeatureClient.test.ts
@@ -84,9 +84,6 @@ describe("OctopusFeatureClient", () => {
     });
 
     describe("the manifest cache", () => {
-        // jest-localstorage-mock's getItem/setItem close over instance state via jest.fn(impl), which
-        // jest.config.js's resetMocks strips before every test. A plain in-memory Storage sidesteps
-        // that entirely, since resetMocks only touches mocks it created.
         beforeEach(() => {
             const store = new Map<string, string>();
             global.localStorage = {

--- a/src/octopusFeatureClient.ts
+++ b/src/octopusFeatureClient.ts
@@ -1,14 +1,24 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 import axiosRetry from "axios-retry";
-import { V2FeatureToggleEvaluation, V2FeatureToggles, OctopusFeatureContext } from "./octopusFeatureContext";
-import { OctopusFeatureConfiguration } from "./octopusFeatureProvider";
 import { DefaultLogger, Logger } from "@openfeature/web-sdk";
+import { OctopusFeatureContext } from "./octopusFeatureContext";
+import { OctopusFeatureConfiguration } from "./octopusFeatureProvider";
 import { ProductMetadata } from "./productMetadata";
+import { parseServerSideEvaluations } from "./v4/parseServerSideEvaluation";
 import { PROVIDER_VERSION } from "./version";
 
-interface V2CacheEntry {
-    schemaVersion: "v2";
-    contents: V2FeatureToggles;
+interface FeatureManifest {
+    // Unparsed, exactly as received from the v4 endpoint (or replayed from a cache entry) — parsed
+    // into ServerSideEvaluation instances at the one place that needs them, in getEvaluationContext.
+    evaluations: unknown;
+    contentHash: string;
+}
+
+interface V3CacheEntry {
+    // This counts cache shapes, not endpoint versions: "v2" shipped a payload change under the same
+    // /v3/ route, so bumping in lockstep with the API here would be a lie the next time that happens.
+    schemaVersion: "v3";
+    contents: FeatureManifest;
 }
 
 export class OctopusFeatureClient {
@@ -40,42 +50,54 @@ export class OctopusFeatureClient {
         const manifest = await this.getFeatureManifest();
 
         if (manifest === undefined) {
-            const rawCache = localStorage.getItem(this.localStorageKey);
-            if (rawCache === null) {
-                return new OctopusFeatureContext({ evaluations: [], contentHash: "" });
-            }
-
-            try {
-                const cacheEntry = JSON.parse(rawCache);
-                if (this.isV2CacheEntry(cacheEntry)) {
-                    return new OctopusFeatureContext(cacheEntry.contents);
-                }
-            } catch (e) {
-                this.logger.warn(`An error occurred parsing feature toggles returned from Octopus: ${JSON.stringify(e)}`);
-            }
-
-            return new OctopusFeatureContext({ evaluations: [], contentHash: "" });
+            return this.getEvaluationContextFromCache();
         }
 
-        const cacheEntry: V2CacheEntry = { schemaVersion: "v2", contents: manifest };
+        const cacheEntry: V3CacheEntry = { schemaVersion: "v3", contents: manifest };
         localStorage.setItem(this.localStorageKey, JSON.stringify(cacheEntry));
 
-        return new OctopusFeatureContext(manifest);
+        return new OctopusFeatureContext(parseServerSideEvaluations(manifest.evaluations), this.logger);
     }
 
-    isV2CacheEntry(entry: unknown): entry is V2CacheEntry {
-        const possibleV2CacheEntry = entry as V2CacheEntry;
+    private getEvaluationContextFromCache(): OctopusFeatureContext {
+        const rawCache = localStorage.getItem(this.localStorageKey);
+        if (rawCache === null) {
+            return this.emptyContext();
+        }
+
+        try {
+            const cacheEntry = JSON.parse(rawCache);
+            if (this.isV3CacheEntry(cacheEntry)) {
+                return new OctopusFeatureContext(parseServerSideEvaluations(cacheEntry.contents.evaluations), this.logger);
+            }
+
+            // A cache entry from a previous schema version is a miss, not something to reshape: a v3
+            // payload cannot be turned into v4 rules. Removed rather than left orphaned.
+            localStorage.removeItem(this.localStorageKey);
+        } catch (e) {
+            this.logger.warn(`An error occurred parsing feature toggles returned from Octopus: ${JSON.stringify(e)}`);
+        }
+
+        return this.emptyContext();
+    }
+
+    private emptyContext(): OctopusFeatureContext {
+        return new OctopusFeatureContext([], this.logger);
+    }
+
+    private isV3CacheEntry(entry: unknown): entry is V3CacheEntry {
+        const possibleV3CacheEntry = entry as V3CacheEntry;
         return (
-            possibleV2CacheEntry.schemaVersion === "v2" &&
-            possibleV2CacheEntry.contents !== undefined &&
-            possibleV2CacheEntry.contents.evaluations !== undefined &&
-            possibleV2CacheEntry.contents.contentHash !== undefined
+            possibleV3CacheEntry.schemaVersion === "v3" &&
+            possibleV3CacheEntry.contents !== undefined &&
+            possibleV3CacheEntry.contents.evaluations !== undefined &&
+            possibleV3CacheEntry.contents.contentHash !== undefined
         );
     }
 
-    async getFeatureManifest(): Promise<V2FeatureToggles | undefined> {
+    async getFeatureManifest(): Promise<FeatureManifest | undefined> {
         const config: AxiosRequestConfig = {
-            url: `${this.serverUri}/api/toggles/evaluations/v3/`,
+            url: `${this.serverUri}/api/feature-flags/evaluations/v4/`,
             maxContentLength: Infinity,
             maxBodyLength: Infinity,
             method: "GET",
@@ -89,7 +111,7 @@ export class OctopusFeatureClient {
             config.headers!["X-Release-Version"] = this.releaseVersionOverride;
         }
 
-        const response = await this.axiosInstance.request<V2FeatureToggleEvaluation[]>(config);
+        const response = await this.axiosInstance.request<unknown>(config);
 
         if (response.status == 404) {
             this.logger.warn(`Failed to retrieve feature toggles for client identifier ${this.clientIdentifier} from ${this.serverUri}`);

--- a/src/octopusFeatureClient.ts
+++ b/src/octopusFeatureClient.ts
@@ -8,15 +8,13 @@ import { parseServerSideEvaluations } from "./v4/parseServerSideEvaluation";
 import { PROVIDER_VERSION } from "./version";
 
 interface FeatureManifest {
-    // Unparsed, exactly as received from the v4 endpoint (or replayed from a cache entry) — parsed
-    // into ServerSideEvaluation instances at the one place that needs them, in getEvaluationContext.
+    // Unparsed, exactly as received from the v4 endpoint (or replayed from a cache entry).
     evaluations: unknown;
     contentHash: string;
 }
 
 interface V3CacheEntry {
-    // This counts cache shapes, not endpoint versions: "v2" shipped a payload change under the same
-    // /v3/ route, so bumping in lockstep with the API here would be a lie the next time that happens.
+    // Note: This counts cache shapes, not endpoint versions.
     schemaVersion: "v3";
     contents: FeatureManifest;
 }
@@ -71,11 +69,10 @@ export class OctopusFeatureClient {
                 return new OctopusFeatureContext(parseServerSideEvaluations(cacheEntry.contents.evaluations), this.logger);
             }
 
-            // A cache entry from a previous schema version is a miss, not something to reshape: a v3
-            // payload cannot be turned into v4 rules. Removed rather than left orphaned.
+            // The cached entry is from an old cache schema version.
             localStorage.removeItem(this.localStorageKey);
         } catch (e) {
-            this.logger.warn(`An error occurred parsing feature toggles returned from Octopus: ${JSON.stringify(e)}`);
+            this.logger.warn(`Failed to retrieve feature flags: ${JSON.stringify(e)}`);
         }
 
         return this.emptyContext();

--- a/src/octopusFeatureClient.ts
+++ b/src/octopusFeatureClient.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import axiosRetry from "axios-retry";
 import { DefaultLogger, Logger } from "@openfeature/web-sdk";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
@@ -108,10 +108,9 @@ export class OctopusFeatureClient {
             config.headers!["X-Release-Version"] = this.releaseVersionOverride;
         }
 
-        const response = await this.axiosInstance.request<unknown>(config);
+        const response = await this.requestEvaluations(config);
 
-        if (response.status == 404) {
-            this.logger.warn(`Failed to retrieve feature toggles for client identifier ${this.clientIdentifier} from ${this.serverUri}`);
+        if (response === undefined) {
             return undefined;
         }
 
@@ -123,6 +122,21 @@ export class OctopusFeatureClient {
         }
 
         return { evaluations: response.data, contentHash: contentHash };
+    }
+
+    /**
+     * Reports no manifest, rather than rejecting, when the request fails: an unreachable server, or any
+     * unsuccessful status once axios-retry has given up.
+     */
+    private async requestEvaluations(config: AxiosRequestConfig): Promise<AxiosResponse<unknown> | undefined> {
+        try {
+            return await this.axiosInstance.request<unknown>(config);
+        } catch (e) {
+            this.logger.warn(
+                `Failed to retrieve feature manifest during initialization. Falling back to cached evaluations, if present.\n${JSON.stringify(e)}`
+            );
+            return undefined;
+        }
     }
 
     private buildOctopusClientHeaderValue(): string {

--- a/src/octopusFeatureContext.test.ts
+++ b/src/octopusFeatureContext.test.ts
@@ -1,384 +1,118 @@
-import { V2FeatureToggles, OctopusFeatureContext } from "./octopusFeatureContext";
-import { ErrorCode } from "@openfeature/core";
+import { ErrorCode, FlagNotFoundError } from "@openfeature/core";
+import { ParseError } from "@openfeature/web-sdk";
+import * as Contexts from "./testing/contexts";
+import { silentLogger } from "./testing/logger";
+import { OctopusFeatureContext } from "./octopusFeatureContext";
+import { ClientSideRule } from "./v4/clientSideRule";
+import { ContextAttributeIsOneOfCondition } from "./v4/conditions/contextAttributeIsOneOfCondition";
+import { ServerSideEvaluation } from "./v4/serverSideEvaluation";
 
-describe("Given a set of feature toggles", () => {
-    test("Evaluates to true if feature is contained within the set and enabled", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "test-feature",
-                    isEnabled: true,
-                    evaluationKey: "evaluation-key",
-                    segments: [],
-                    clientRolloutPercentage: 100,
-                },
-            ],
-            contentHash: "",
-        };
+// Evaluating a slug's rules is ServerSideEvaluation's job, covered in v4/serverSideEvaluation.test.ts
+// and the condition tests. This covers what OctopusFeatureContext adds on top: slug lookup, the
+// FlagNotFoundError contract, and the warn-once behaviour.
+describe("OctopusFeatureContext", () => {
+    function resolved(slug: string, value: boolean, reason: string): ServerSideEvaluation {
+        return new ServerSideEvaluation(slug, value, reason);
+    }
 
-        const context = new OctopusFeatureContext(toggles);
+    describe("findToggleBySlug", () => {
+        test("Finds an evaluation by exact slug", () => {
+            const evaluation = resolved("my-feature", true, "The flag is enabled for this environment.");
+            const context = new OctopusFeatureContext([evaluation], silentLogger());
 
-        expect(context.evaluate("test-feature", false, {})).toStrictEqual({ value: true });
-    });
-
-    test("Evaluates to true if feature is contained within the set and enabled, and evaluation casing differs", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "test-feature",
-                    isEnabled: true,
-                    evaluationKey: "evaluation-key",
-                    segments: [],
-                    clientRolloutPercentage: 100,
-                },
-            ],
-            contentHash: "",
-        };
-
-        const context = new OctopusFeatureContext(toggles);
-
-        expect(context.evaluate("Test-Feature", false, {})).toStrictEqual({ value: true });
-    });
-
-    test("Evaluates to false if feature is contained within the set but is not enabled", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "test-feature",
-                    isEnabled: false,
-                },
-            ],
-            contentHash: "",
-        };
-
-        const context = new OctopusFeatureContext(toggles);
-
-        expect(context.evaluate("test-feature", false, {})).toStrictEqual({ value: false });
-    });
-
-    describe("When flag key provided is not a slug", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "this-is-clearly-not-a-slug",
-                    isEnabled: false,
-                },
-            ],
-            contentHash: "",
-        };
-
-        const context = new OctopusFeatureContext(toggles);
-
-        const result = context.evaluate("This is clearly not a slug!", true, {});
-
-        test("Then error code is flag not found", () => {
-            expect(result.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+            expect(context.findToggleBySlug("my-feature")).toBe(evaluation);
         });
 
-        test("Then the default value is returned", () => {
-            expect(result.value).toBe(true);
+        test("Finds an evaluation when the slug casing differs", () => {
+            const evaluation = resolved("my-feature", true, "The flag is enabled for this environment.");
+            const context = new OctopusFeatureContext([evaluation], silentLogger());
+
+            expect(context.findToggleBySlug("My-Feature")).toBe(evaluation);
+        });
+
+        test("Does not find an evaluation for an unrecognised slug", () => {
+            const context = new OctopusFeatureContext([resolved("my-feature", true, "reason")], silentLogger());
+
+            expect(context.findToggleBySlug("another-feature")).toBeUndefined();
+        });
+
+        test("An evaluation without a slug is never matched", () => {
+            const evaluation = new ServerSideEvaluation(undefined as unknown as string, true, "reason");
+            const context = new OctopusFeatureContext([evaluation], silentLogger());
+
+            expect(context.findToggleBySlug("undefined")).toBeUndefined();
         });
     });
 
-    describe("When flag is not present within the set", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "testfeature",
-                    isEnabled: false,
-                },
-            ],
-            contentHash: "",
-        };
+    describe("evaluate", () => {
+        test("Delegates a server-resolved evaluation, passing its value and reason through unchanged", () => {
+            const context = new OctopusFeatureContext([resolved("my-feature", true, "The flag is enabled for this environment.")], silentLogger());
 
-        const context = new OctopusFeatureContext(toggles);
-
-        const result = context.evaluate("anotherfeature", true, {});
-
-        test("Then error code is flag not found", () => {
-            expect(result.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+            expect(context.evaluate("my-feature", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
         });
 
-        test("Then the default value is returned", () => {
-            expect(result.value).toBe(true);
-        });
-    });
+        test("Delegates a deferred evaluation to its rules", () => {
+            const evaluation = new ServerSideEvaluation("my-feature", undefined, undefined, Contexts.EvaluationKey, [
+                new ClientSideRule("Beta ring", [new ContextAttributeIsOneOfCondition("ring", ["beta"])]),
+            ]);
+            const context = new OctopusFeatureContext([evaluation], silentLogger());
 
-    describe("When a feature is toggled on for a specific segment", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "testfeature",
-                    isEnabled: true,
-                    evaluationKey: "evaluation-key",
-                    segments: [{ key: "license", value: "trial" }],
-                    clientRolloutPercentage: 100,
-                },
-            ],
-            contentHash: "",
-        };
+            const result = context.evaluate("my-feature", Contexts.openFeature(undefined, { ring: "beta" }));
 
-        const context = new OctopusFeatureContext(toggles);
-
-        test("Evaluates to true if the segment is specified", () => {
-            const result = context.evaluate("testfeature", false, { license: "trial" });
-            expect(result).toStrictEqual({ value: true });
+            expect(result).toEqual({ value: true, reason: "Matched rule 'Beta ring'." });
         });
 
-        test("Evaluates to false if an invalid segment is specified", () => {
-            const result = context.evaluate("testfeature", false, { other: "segment" });
-            expect(result).toStrictEqual({ value: false });
+        test("Looks the slug up case-insensitively", () => {
+            const context = new OctopusFeatureContext([resolved("my-feature", true, "The flag is enabled for this environment.")], silentLogger());
+
+            expect(context.evaluate("MY-FEATURE", {})).toEqual({ value: true, reason: "The flag is enabled for this environment." });
         });
 
-        test("Evaluates to false if no segment is specified", () => {
-            const result = context.evaluate("testfeature", false, {});
-            expect(result).toStrictEqual({ value: false });
-        });
-    });
+        test("Throws FlagNotFoundError for an unrecognised slug", () => {
+            const context = new OctopusFeatureContext([], silentLogger());
 
-    describe("When a feature is not toggled on for a specific segment", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "testfeature",
-                    isEnabled: true,
-                    evaluationKey: "evaluation-key",
-                    segments: [],
-                    clientRolloutPercentage: 100,
-                },
-            ],
-            contentHash: "",
-        };
-
-        const context = new OctopusFeatureContext(toggles);
-
-        test("Evaluates to true regardless of the segment specified", () => {
-            const result = context.evaluate("testfeature", false, { license: "trial" });
-            expect(result).toStrictEqual({ value: true });
+            expect(() => context.evaluate("missing-feature", {})).toThrow(
+                new FlagNotFoundError("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.")
+            );
         });
 
-        test("Evaluates to true when no context values are specified", () => {
-            const result = context.evaluate("testfeature", false, {});
-            expect(result).toStrictEqual({ value: true });
-        });
-    });
+        test("A FlagNotFoundError carries the FLAG_NOT_FOUND error code", () => {
+            const context = new OctopusFeatureContext([], silentLogger());
 
-    describe("When a feature is toggled on for multiple segments", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "testfeature",
-                    isEnabled: true,
-                    evaluationKey: "evaluation-key",
-                    segments: [
-                        { key: "license", value: "trial" },
-                        { key: "region", value: "au" },
-                        { key: "region", value: "us" },
-                    ],
-                    clientRolloutPercentage: 100,
-                },
-            ],
-            contentHash: "",
-        };
-
-        const context = new OctopusFeatureContext(toggles);
-
-        test("Evaluates to true if a matching context value is present for each toggled segment", () => {
-            const result = context.evaluate("testfeature", false, { license: "trial", region: "us" });
-            expect(result).toStrictEqual({ value: true });
+            expect.assertions(1);
+            try {
+                context.evaluate("missing-feature", {});
+            } catch (e) {
+                expect((e as FlagNotFoundError).code).toBe(ErrorCode.FLAG_NOT_FOUND);
+            }
         });
 
-        test("Evaluates to false if a context value is present for each toggled segment but one does not match", () => {
-            const result = context.evaluate("testfeature", false, { license: "trial", region: "eu" });
-            expect(result).toStrictEqual({ value: false });
+        test("Propagates a ParseError from an unreadable evaluation", () => {
+            const evaluation = new ServerSideEvaluation("my-feature", true); // value with no reason
+            const context = new OctopusFeatureContext([evaluation], silentLogger());
+
+            expect(() => context.evaluate("my-feature", {})).toThrow(ParseError);
         });
 
-        test("Evaluates to true if a matching context value is present for each toggled segment and an additional segment is present", () => {
-            const result = context.evaluate("testfeature", false, { license: "trial", region: "us", language: "english" });
-            expect(result).toStrictEqual({ value: true });
+        test("Warns only once for a repeated unrecognised slug", () => {
+            const logger = silentLogger();
+            const context = new OctopusFeatureContext([], logger);
+
+            expect(() => context.evaluate("missing-feature", {})).toThrow(FlagNotFoundError);
+            expect(() => context.evaluate("missing-feature", {})).toThrow(FlagNotFoundError);
+            expect(() => context.evaluate("Missing-Feature", {})).toThrow(FlagNotFoundError);
+
+            expect(logger.warn).toHaveBeenCalledTimes(1);
         });
 
-        test("Evaluates to false if a context value is present for only one of the toggled segments", () => {
-            const result = context.evaluate("testfeature", false, { license: "trial" });
-            expect(result).toStrictEqual({ value: false });
+        test("Warns again for a different unrecognised slug", () => {
+            const logger = silentLogger();
+            const context = new OctopusFeatureContext([], logger);
+
+            expect(() => context.evaluate("missing-feature-a", {})).toThrow(FlagNotFoundError);
+            expect(() => context.evaluate("missing-feature-b", {})).toThrow(FlagNotFoundError);
+
+            expect(logger.warn).toHaveBeenCalledTimes(2);
         });
-
-        test("Evaluates to false if no context values are present for any of the toggled segments", () => {
-            const result = context.evaluate("testfeature", true, { other: "segment" });
-            expect(result).toStrictEqual({ value: false });
-        });
-
-        test("Evaluates to false if no context values are specified", () => {
-            const result = context.evaluate("testfeature", true, {});
-            expect(result).toStrictEqual({ value: false });
-        });
-    });
-
-    describe("When a feature is toggled on for a specific segment and context is missing the segment key", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                {
-                    slug: "testfeature",
-                    isEnabled: true,
-                    evaluationKey: "evaluation-key",
-                    segments: [{ key: "license", value: "trial" }],
-                    clientRolloutPercentage: 100,
-                },
-            ],
-            contentHash: "",
-        };
-
-        const context = new OctopusFeatureContext(toggles);
-
-        test("Evaluates to false if the segment key is present but has a null value", () => {
-            const result = context.evaluate("testfeature", false, { license: null as unknown as string });
-            expect(result).toStrictEqual({ value: false });
-        });
-
-        test("Evaluates to false if a different segment key is specified", () => {
-            const result = context.evaluate("testfeature", false, { other: "segment" });
-            expect(result).toStrictEqual({ value: false });
-        });
-
-        test("Evaluates to false if no context values are specified", () => {
-            const result = context.evaluate("testfeature", false, {});
-            expect(result).toStrictEqual({ value: false });
-        });
-    });
-});
-
-describe("Rollout percentage evaluation", () => {
-    // "evaluation-key:targeting-key" hashes to bucket 13
-    const evaluationKey = "evaluation-key";
-    const targetingKey = "targeting-key";
-
-    test("Evaluates to true when targeting key falls within rollout percentage and no segments required", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "test-feature", isEnabled: true, evaluationKey, segments: [], clientRolloutPercentage: 13 }],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, { targetingKey });
-        expect(result).toStrictEqual({ value: true });
-    });
-
-    test("Evaluates to false when targeting key falls outside rollout percentage and no segments required", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "test-feature", isEnabled: true, evaluationKey, segments: [], clientRolloutPercentage: 12 }],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, { targetingKey });
-        expect(result).toStrictEqual({ value: false });
-    });
-
-    test("Evaluates to true when targeting key falls within rollout percentage and segment matches", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                { slug: "test-feature", isEnabled: true, evaluationKey, segments: [{ key: "license", value: "trial" }], clientRolloutPercentage: 13 },
-            ],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, { targetingKey, license: "trial" });
-        expect(result).toStrictEqual({ value: true });
-    });
-
-    test("Evaluates to false when targeting key falls within rollout percentage but segment does not match", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                { slug: "test-feature", isEnabled: true, evaluationKey, segments: [{ key: "license", value: "enterprise" }], clientRolloutPercentage: 99 },
-            ],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, { targetingKey, license: "trial" });
-        expect(result).toStrictEqual({ value: false });
-    });
-
-    test("Evaluates to false when targeting key falls outside rollout percentage and segment does not match", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [
-                { slug: "test-feature", isEnabled: true, evaluationKey, segments: [{ key: "license", value: "enterprise" }], clientRolloutPercentage: 12 },
-            ],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, { targetingKey, license: "trial" });
-        expect(result).toStrictEqual({ value: false });
-    });
-
-    test("Evaluates to false when no targeting key and rollout is less than 100%", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "test-feature", isEnabled: true, evaluationKey, segments: [], clientRolloutPercentage: 99 }],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, {});
-        expect(result).toStrictEqual({ value: false });
-    });
-
-    test("Evaluates to true when no targeting key and rollout is 100%", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "test-feature", isEnabled: true, evaluationKey, segments: [], clientRolloutPercentage: 100 }],
-            contentHash: "",
-        };
-        const result = new OctopusFeatureContext(toggles).evaluate("test-feature", false, {});
-        expect(result).toStrictEqual({ value: true });
-    });
-});
-
-describe("When an enabled toggle is missing required client evaluation fields", () => {
-    test("Returns PARSE_ERROR when evaluationKey is absent", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "feature-a", isEnabled: true, segments: [], clientRolloutPercentage: 100 }],
-            contentHash: "",
-        };
-        const context = new OctopusFeatureContext(toggles);
-        const result = context.evaluate("feature-a", false, {});
-        expect(result.errorCode).toBe(ErrorCode.PARSE_ERROR);
-        expect(result.errorMessage).toContain("missing necessary information for client-side evaluation");
-        expect(result.value).toBe(false);
-    });
-
-    test("Returns PARSE_ERROR when segments is absent", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "feature-b", isEnabled: true, evaluationKey: "evaluation-key", clientRolloutPercentage: 100 }],
-            contentHash: "",
-        };
-        const context = new OctopusFeatureContext(toggles);
-        const result = context.evaluate("feature-b", false, {});
-        expect(result.errorCode).toBe(ErrorCode.PARSE_ERROR);
-        expect(result.errorMessage).toContain("missing necessary information for client-side evaluation");
-        expect(result.value).toBe(false);
-    });
-
-    test("Returns PARSE_ERROR when clientRolloutPercentage is absent", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "feature-c", isEnabled: true, evaluationKey: "evaluation-key", segments: [] }],
-            contentHash: "",
-        };
-        const context = new OctopusFeatureContext(toggles);
-        const result = context.evaluate("feature-c", false, {});
-        expect(result.errorCode).toBe(ErrorCode.PARSE_ERROR);
-        expect(result.errorMessage).toContain("missing necessary information for client-side evaluation");
-        expect(result.value).toBe(false);
-    });
-
-    test("Returns PARSE_ERROR when all three fields are absent", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "feature-d", isEnabled: true }],
-            contentHash: "",
-        };
-        const context = new OctopusFeatureContext(toggles);
-        const result = context.evaluate("feature-d", true, {});
-        expect(result.errorCode).toBe(ErrorCode.PARSE_ERROR);
-        expect(result.errorMessage).toContain("missing necessary information for client-side evaluation");
-        expect(result.value).toBe(true);
-    });
-
-    test("Does not return PARSE_ERROR for a disabled toggle with absent fields", () => {
-        const toggles: V2FeatureToggles = {
-            evaluations: [{ slug: "feature-e", isEnabled: false }],
-            contentHash: "",
-        };
-        const context = new OctopusFeatureContext(toggles);
-        const result = context.evaluate("feature-e", true, {});
-        expect(result.errorCode).toBeUndefined();
-        expect(result.value).toBe(false);
     });
 });

--- a/src/octopusFeatureContext.test.ts
+++ b/src/octopusFeatureContext.test.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, FlagNotFoundError } from "@openfeature/core";
+import { FlagNotFoundError } from "@openfeature/core";
 import { ParseError } from "@openfeature/web-sdk";
 import * as Contexts from "./testing/contexts";
 import { silentLogger } from "./testing/logger";
@@ -74,17 +74,6 @@ describe("OctopusFeatureContext", () => {
             expect(() => context.evaluate("missing-feature", {})).toThrow(
                 new FlagNotFoundError("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.")
             );
-        });
-
-        test("A FlagNotFoundError carries the FLAG_NOT_FOUND error code", () => {
-            const context = new OctopusFeatureContext([], silentLogger());
-
-            expect.assertions(1);
-            try {
-                context.evaluate("missing-feature", {});
-            } catch (e) {
-                expect((e as FlagNotFoundError).code).toBe(ErrorCode.FLAG_NOT_FOUND);
-            }
         });
 
         test("Propagates a ParseError from an unreadable evaluation", () => {

--- a/src/octopusFeatureContext.test.ts
+++ b/src/octopusFeatureContext.test.ts
@@ -1,5 +1,4 @@
-import { FlagNotFoundError } from "@openfeature/core";
-import { ParseError } from "@openfeature/web-sdk";
+import { FlagNotFoundError, ParseError } from "@openfeature/web-sdk";
 import * as Contexts from "./testing/contexts";
 import { silentLogger } from "./testing/logger";
 import { OctopusFeatureContext } from "./octopusFeatureContext";

--- a/src/octopusFeatureContext.ts
+++ b/src/octopusFeatureContext.ts
@@ -1,5 +1,4 @@
-import { EvaluationContext, Logger, ResolutionDetails } from "@openfeature/web-sdk";
-import { FlagNotFoundError } from "@openfeature/core";
+import { EvaluationContext, FlagNotFoundError, Logger, ResolutionDetails } from "@openfeature/web-sdk";
 import { equalsIgnoringCase } from "./equalsIgnoringCase";
 import { ServerSideEvaluation } from "./v4/serverSideEvaluation";
 

--- a/src/octopusFeatureContext.ts
+++ b/src/octopusFeatureContext.ts
@@ -19,8 +19,6 @@ export interface V2FeatureToggleEvaluation {
 }
 
 export class OctopusFeatureContext {
-    // Slugs already warned about, folded the same way as the lookup below, so a typo'd slug re-rendered
-    // thousands of times costs one console line rather than thousands.
     private readonly warnedSlugs = new Set<string>();
 
     constructor(
@@ -36,20 +34,15 @@ export class OctopusFeatureContext {
         const evaluation = this.findToggleBySlug(slug);
 
         if (!evaluation) {
-            this.warnUnrecognisedSlugOnce(slug);
+            const key = slug.toUpperCase();
+            if (!this.warnedSlugs.has(key)) {
+                this.logger.warn(`The slug '${slug}' did not match any of your Octopus Feature Flags. Please double check your slug and try again.`);
+                this.warnedSlugs.add(key);
+            }
+
             throw new FlagNotFoundError("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.");
         }
 
         return evaluation.evaluate(context);
-    }
-
-    private warnUnrecognisedSlugOnce(slug: string): void {
-        const key = slug.toUpperCase();
-        if (this.warnedSlugs.has(key)) {
-            return;
-        }
-
-        this.warnedSlugs.add(key);
-        this.logger.warn(`The slug '${slug}' did not match any of your Octopus Feature Flags. This will only be logged once per slug.`);
     }
 }

--- a/src/octopusFeatureContext.ts
+++ b/src/octopusFeatureContext.ts
@@ -1,7 +1,10 @@
-import { EvaluationContext, ResolutionDetails } from "@openfeature/web-sdk";
-import { ErrorCode } from "@openfeature/core";
-import { getNormalizedNumber } from "./v4/percentageRollout";
+import { EvaluationContext, Logger, ResolutionDetails } from "@openfeature/web-sdk";
+import { FlagNotFoundError } from "@openfeature/core";
+import { equalsIgnoringCase } from "./equalsIgnoringCase";
+import { ServerSideEvaluation } from "./v4/serverSideEvaluation";
 
+// Superseded by ServerSideEvaluation below. Left in place, unreferenced, for BMBB-781 to remove along
+// with the rest of the v3 "toggle" vocabulary.
 export interface V2FeatureToggles {
     evaluations: V2FeatureToggleEvaluation[];
     contentHash: string;
@@ -16,99 +19,37 @@ export interface V2FeatureToggleEvaluation {
 }
 
 export class OctopusFeatureContext {
-    toggles: V2FeatureToggles;
+    // Slugs already warned about, folded the same way as the lookup below, so a typo'd slug re-rendered
+    // thousands of times costs one console line rather than thousands.
+    private readonly warnedSlugs = new Set<string>();
 
-    constructor(toggles: V2FeatureToggles) {
-        this.toggles = toggles;
+    constructor(
+        private readonly evaluations: readonly ServerSideEvaluation[],
+        private readonly logger: Logger
+    ) {}
+
+    findToggleBySlug(slug: string): ServerSideEvaluation | undefined {
+        return this.evaluations.find((evaluation) => typeof evaluation.slug === "string" && equalsIgnoringCase(evaluation.slug, slug));
     }
 
-    findToggleBySlug(slug: string): V2FeatureToggleEvaluation | undefined {
-        return this.toggles.evaluations.find((feature) => feature.slug.toLowerCase() === slug.toLowerCase());
-    }
-
-    evaluate(slug: string, defaultValue: boolean, context: EvaluationContext): ResolutionDetails<boolean> {
+    evaluate(slug: string, context: EvaluationContext): ResolutionDetails<boolean> {
         const evaluation = this.findToggleBySlug(slug);
 
         if (!evaluation) {
-            return {
-                value: defaultValue,
-                errorCode: ErrorCode.FLAG_NOT_FOUND,
-                errorMessage: "The slug provided did not match any of your Octopus Feature Toggles. Please double check your slug and try again.",
-            };
+            this.warnUnrecognisedSlugOnce(slug);
+            throw new FlagNotFoundError("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.");
         }
 
-        if (missingRequiredPropertiesForClientSideEvaluation(evaluation)) {
-            return {
-                value: defaultValue,
-                errorCode: ErrorCode.PARSE_ERROR,
-                errorMessage: `Feature toggle ${slug} is missing necessary information for client-side evaluation.`,
-            };
+        return evaluation.evaluate(context);
+    }
+
+    private warnUnrecognisedSlugOnce(slug: string): void {
+        const key = slug.toUpperCase();
+        if (this.warnedSlugs.has(key)) {
+            return;
         }
 
-        return { value: this.evaluateSegments(evaluation, context) };
+        this.warnedSlugs.add(key);
+        this.logger.warn(`The slug '${slug}' did not match any of your Octopus Feature Flags. This will only be logged once per slug.`);
     }
-
-    matchesSegment(context: EvaluationContext, segments: { key: string; value: string }[]): boolean {
-        if (!context) return false;
-
-        // Group segments by key
-        const groupedSegments = segments.reduce(
-            (groups, segment) => {
-                if (!groups[segment.key]) {
-                    groups[segment.key] = [];
-                }
-                groups[segment.key].push(segment.value);
-                return groups;
-            },
-            {} as Record<string, string[]>
-        );
-
-        // Check if all segment groups have at least one matching context entry
-        const result = Object.keys(groupedSegments).every((segmentKey) => {
-            const group = groupedSegments[segmentKey];
-            return group.some((segment) =>
-                Object.keys(context).some((contextKey) => {
-                    const contextValue = context[contextKey];
-                    if (typeof contextValue === "string") {
-                        return contextKey === segmentKey && contextValue === segment;
-                    }
-                    return false;
-                })
-            );
-        });
-
-        return result;
-    }
-
-    evaluateSegments(evaluation: V2FeatureToggleEvaluation, context: EvaluationContext): boolean {
-        if (!evaluation.isEnabled) {
-            return false;
-        }
-
-        // evaluationKey and clientRolloutPercentage are guaranteed to be present here via missingRequiredPropertiesForClientSideEvaluation check
-        const evaluationKey = evaluation.evaluationKey!;
-        const rolloutPercentage = evaluation.clientRolloutPercentage!;
-        const targetingKey = context?.targetingKey;
-
-        if (!targetingKey) {
-            if (rolloutPercentage < 100) {
-                return false;
-            }
-            // rolloutPercentage == 100: fall through to segment check
-        } else {
-            if (getNormalizedNumber(evaluationKey, targetingKey) > rolloutPercentage) {
-                return false;
-            }
-        }
-
-        const hasSegments = evaluation.segments != null && evaluation.segments.length > 0;
-        return !hasSegments || this.matchesSegment(context, evaluation.segments!);
-    }
-}
-
-function missingRequiredPropertiesForClientSideEvaluation(evaluation: V2FeatureToggleEvaluation): boolean {
-    if (!evaluation.isEnabled) {
-        return false;
-    }
-    return evaluation.evaluationKey == null || evaluation.segments == null || evaluation.clientRolloutPercentage == null;
 }

--- a/src/octopusFeatureProvider.test.ts
+++ b/src/octopusFeatureProvider.test.ts
@@ -4,6 +4,10 @@ import { OpenFeature } from "@openfeature/web-sdk";
 import { ErrorCode } from "@openfeature/core";
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
+import { silentLogger } from "./testing/logger";
+import { ClientSideRule } from "./v4/clientSideRule";
+import { ContextAttributeIsOneOfCondition } from "./v4/conditions/contextAttributeIsOneOfCondition";
+import { ServerSideEvaluation } from "./v4/serverSideEvaluation";
 
 jest.mock("./octopusFeatureClient");
 
@@ -37,20 +41,18 @@ describe("Context is available for segment evaluation immediately after provider
     beforeEach(async () => {
         await OpenFeature.setContext({});
         jest.mocked(OctopusFeatureClient).mockClear();
-        jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest.fn().mockResolvedValue(
-            new OctopusFeatureContext({
-                evaluations: [
-                    {
-                        slug: "segmented-feature",
-                        isEnabled: true,
-                        evaluationKey: "evaluation-key",
-                        segments: [{ key: "serverUri", value: "app.example.com" }],
-                        clientRolloutPercentage: 100,
-                    },
-                ],
-                contentHash: "",
-            })
-        );
+        jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest
+            .fn()
+            .mockResolvedValue(
+                new OctopusFeatureContext(
+                    [
+                        new ServerSideEvaluation("segmented-feature", undefined, undefined, "evaluation-key", [
+                            new ClientSideRule("Client-side targeting", [new ContextAttributeIsOneOfCondition("serverUri", ["app.example.com"])]),
+                        ]),
+                    ],
+                    silentLogger()
+                )
+            );
     });
 
     test("setContext before setProviderAndWait — SDK passes context to initialize", async () => {
@@ -103,20 +105,11 @@ describe("Flag type errors are surfaced correctly", () => {
     beforeEach(async () => {
         await OpenFeature.setContext({});
         jest.mocked(OctopusFeatureClient).mockClear();
-        jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest.fn().mockResolvedValue(
-            new OctopusFeatureContext({
-                evaluations: [
-                    {
-                        slug: "feature-a",
-                        isEnabled: true,
-                        evaluationKey: "key",
-                        segments: [],
-                        clientRolloutPercentage: 100,
-                    },
-                ],
-                contentHash: "",
-            })
-        );
+        jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest
+            .fn()
+            .mockResolvedValue(
+                new OctopusFeatureContext([new ServerSideEvaluation("feature-a", true, "The flag is enabled for this environment.")], silentLogger())
+            );
         const provider = new OctopusFeatureProvider({
             clientIdentifier: "test",
             productMetadata: new ProductMetadata("TestClient"),
@@ -150,5 +143,36 @@ describe("Flag type errors are surfaced correctly", () => {
 
     test("givenAnUnknownFlag_whenRequestedAsObject_returnsFlagNotFound", () => {
         expect(OpenFeature.getClient().getObjectDetails("nonexistent", {}).errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+    });
+});
+
+describe("Unsuccessful boolean evaluations surface the OpenFeature error contract", () => {
+    beforeEach(async () => {
+        await OpenFeature.setContext({});
+        jest.mocked(OctopusFeatureClient).mockClear();
+        jest.mocked(OctopusFeatureClient).prototype.getEvaluationContext = jest
+            .fn()
+            .mockResolvedValue(new OctopusFeatureContext([new ServerSideEvaluation("feature-a", true)], silentLogger())); // value with no reason: malformed
+        const provider = new OctopusFeatureProvider({
+            clientIdentifier: "test",
+            productMetadata: new ProductMetadata("TestClient"),
+        });
+        await OpenFeature.setProviderAndWait(provider);
+    });
+
+    afterEach(async () => {
+        await OpenFeature.clearProviders();
+    });
+
+    test("An unrecognised slug resolves to the caller's default value with FLAG_NOT_FOUND", () => {
+        const result = OpenFeature.getClient().getBooleanDetails("nonexistent", true);
+
+        expect(result).toMatchObject({ value: true, errorCode: ErrorCode.FLAG_NOT_FOUND, reason: "ERROR" });
+    });
+
+    test("A malformed evaluation resolves to the caller's default value with PARSE_ERROR", () => {
+        const result = OpenFeature.getClient().getBooleanDetails("feature-a", false);
+
+        expect(result).toMatchObject({ value: false, errorCode: ErrorCode.PARSE_ERROR, reason: "ERROR" });
     });
 });

--- a/src/octopusFeatureProvider.test.ts
+++ b/src/octopusFeatureProvider.test.ts
@@ -1,7 +1,6 @@
 import { OctopusFeatureProvider } from "./octopusFeatureProvider";
 import { ProductMetadata } from "./productMetadata";
-import { OpenFeature } from "@openfeature/web-sdk";
-import { ErrorCode } from "@openfeature/core";
+import { ErrorCode, OpenFeature } from "@openfeature/web-sdk";
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
 import { silentLogger } from "./testing/logger";

--- a/src/octopusFeatureProvider.ts
+++ b/src/octopusFeatureProvider.ts
@@ -1,5 +1,4 @@
-import { DefaultLogger, EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from "@openfeature/web-sdk";
-import { FlagNotFoundError, TypeMismatchError } from "@openfeature/core";
+import { DefaultLogger, EvaluationContext, FlagNotFoundError, JsonValue, Logger, Provider, ResolutionDetails, TypeMismatchError } from "@openfeature/web-sdk";
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
 import { ProductMetadata } from "./productMetadata";

--- a/src/octopusFeatureProvider.ts
+++ b/src/octopusFeatureProvider.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from "@openfeature/web-sdk";
+import { DefaultLogger, EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from "@openfeature/web-sdk";
 import { FlagNotFoundError, TypeMismatchError } from "@openfeature/core";
 import { OctopusFeatureClient } from "./octopusFeatureClient";
 import { OctopusFeatureContext } from "./octopusFeatureContext";
@@ -20,13 +20,15 @@ export interface OctopusFeatureConfiguration {
 }
 
 export class OctopusFeatureProvider implements Provider {
+    private readonly logger: Logger;
     private client: OctopusFeatureClient;
     private evaluationContext: OctopusFeatureContext;
     private context: EvaluationContext;
 
     constructor(configuration: OctopusFeatureConfiguration) {
+        this.logger = configuration.logger ?? new DefaultLogger();
         this.client = new OctopusFeatureClient(configuration);
-        this.evaluationContext = new OctopusFeatureContext({ evaluations: [], contentHash: "" });
+        this.evaluationContext = new OctopusFeatureContext([], this.logger);
         this.context = {};
     }
 
@@ -50,8 +52,7 @@ export class OctopusFeatureProvider implements Provider {
     }
 
     resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean> {
-        const isFeatureEnabled = this.evaluationContext.evaluate(flagKey, defaultValue, this.context);
-        return isFeatureEnabled;
+        return this.evaluationContext.evaluate(flagKey, this.context);
     }
 
     resolveStringEvaluation(flagKey: string, defaultValue: string): ResolutionDetails<string> {

--- a/src/specificationTests/fixtureEvaluationTests.test.ts
+++ b/src/specificationTests/fixtureEvaluationTests.test.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { ErrorCode } from "@openfeature/core";
-import { OpenFeature } from "@openfeature/web-sdk";
+import { ErrorCode, OpenFeature } from "@openfeature/web-sdk";
 import { OctopusFeatureProvider } from "../octopusFeatureProvider";
 import { ProductMetadata } from "../productMetadata";
 import { Server } from "./server";

--- a/src/specificationTests/fixtureEvaluationTests.test.ts
+++ b/src/specificationTests/fixtureEvaluationTests.test.ts
@@ -25,16 +25,11 @@ interface Case {
 interface Configuration {
     slug: string;
     defaultValue: boolean;
-    // A null models a context attribute that is present but holds no string — distinct from an
-    // attribute the caller left out entirely. A silent coercion here (stringifying it, or dropping the
-    // key) would make the case-insensitivity and excluded-attribute fixtures pass for the wrong reason.
     context?: Record<string, string | null>;
 }
 
 interface Expected {
     value: boolean;
-    // Only asserted when the fixture states one: 11 of the 83 cases carry an errorCode with no reason,
-    // and the SDK populates its own "ERROR" reason for those once failures throw rather than return.
     reason?: string;
     errorCode?: ErrorCode;
 }
@@ -48,11 +43,7 @@ function loadTestCases(): TestEntry[] {
         const json = fs.readFileSync(path.join(fixturesDir, file), "utf-8");
         const fixture: Fixture = JSON.parse(json);
 
-        // .NET forwards its response fixture unparsed via GetRawText(), to avoid a round-trip through
-        // System.Text.Json's configurable (and stricter) serialiser. JSON.parse/JSON.stringify have no
-        // equivalent configurable behaviour to drift from, and round-trip every response in this
-        // repo's fixtures with identical values — confirmed by comparison, not assumed — so parsing and
-        // re-serialising here loses only source formatting, never anything a test can observe.
+        // Unlike in the other client libraries, we can safely parse and re-serialize here.
         const testResponse = JSON.stringify(fixture.response);
 
         for (const c of fixture.cases) {

--- a/src/specificationTests/fixtureEvaluationTests.test.ts
+++ b/src/specificationTests/fixtureEvaluationTests.test.ts
@@ -25,11 +25,17 @@ interface Case {
 interface Configuration {
     slug: string;
     defaultValue: boolean;
-    context?: Record<string, string>;
+    // A null models a context attribute that is present but holds no string — distinct from an
+    // attribute the caller left out entirely. A silent coercion here (stringifying it, or dropping the
+    // key) would make the case-insensitivity and excluded-attribute fixtures pass for the wrong reason.
+    context?: Record<string, string | null>;
 }
 
 interface Expected {
     value: boolean;
+    // Only asserted when the fixture states one: 11 of the 83 cases carry an errorCode with no reason,
+    // and the SDK populates its own "ERROR" reason for those once failures throw rather than return.
+    reason?: string;
     errorCode?: ErrorCode;
 }
 
@@ -40,8 +46,13 @@ function loadTestCases(): TestEntry[] {
     const fixtureFiles = fs.readdirSync(fixturesDir).filter((f) => f.endsWith(".json"));
     for (const file of fixtureFiles) {
         const json = fs.readFileSync(path.join(fixturesDir, file), "utf-8");
-        // Unlike in the other client libraries, we parse and re-serialize here.
         const fixture: Fixture = JSON.parse(json);
+
+        // .NET forwards its response fixture unparsed via GetRawText(), to avoid a round-trip through
+        // System.Text.Json's configurable (and stricter) serialiser. JSON.parse/JSON.stringify have no
+        // equivalent configurable behaviour to drift from, and round-trip every response in this
+        // repo's fixtures with identical values — confirmed by comparison, not assumed — so parsing and
+        // re-serialising here loses only source formatting, never anything a test can observe.
         const testResponse = JSON.stringify(fixture.response);
 
         for (const c of fixture.cases) {
@@ -77,4 +88,7 @@ test.each(testCases)("$testCase.description", async ({ testResponse, testCase })
 
     expect(result.value).toBe(testCase.expected.value);
     expect(result.errorCode).toBe(testCase.expected.errorCode);
+    if (testCase.expected.reason !== undefined) {
+        expect(result.reason).toBe(testCase.expected.reason);
+    }
 });

--- a/src/specificationTests/server.ts
+++ b/src/specificationTests/server.ts
@@ -9,7 +9,7 @@ export class Server {
     start(): Promise<void> {
         return new Promise((resolve, reject) => {
             this.server = http.createServer((req, res) => {
-                if (req.method === "GET" && req.url === "/api/toggles/evaluations/v3/") {
+                if (req.method === "GET" && req.url === "/api/feature-flags/evaluations/v4/") {
                     const authHeader = req.headers["authorization"];
                     if (authHeader && authHeader.startsWith("Bearer ")) {
                         const token = authHeader.slice("Bearer ".length);

--- a/src/testing/logger.ts
+++ b/src/testing/logger.ts
@@ -1,0 +1,6 @@
+import { Logger } from "@openfeature/web-sdk";
+
+/** A Logger stub for tests that need one to construct a provider or context but don't assert on it. */
+export function silentLogger(): Logger {
+    return { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+}

--- a/src/v4/conditions/contextAttributes.ts
+++ b/src/v4/conditions/contextAttributes.ts
@@ -1,4 +1,5 @@
 import { ParseError } from "@openfeature/web-sdk";
+import { equalsIgnoringCase } from "../../equalsIgnoringCase";
 import { ClientSideEvaluationContext } from "../clientSideEvaluationContext";
 
 /**
@@ -40,12 +41,4 @@ export function isOneOf(context: ClientSideEvaluationContext, key: string | unde
 
         return typeof attribute === "string" && values.some((value) => equalsIgnoringCase(value!, attribute));
     });
-}
-
-/**
- * Stands in for .NET's OrdinalIgnoreCase, which folds with invariant uppercase. The two agree on
- * every ASCII input; they part on JavaScript's full case mappings, where "ß" uppercases to "SS" .
- */
-function equalsIgnoringCase(left: string, right: string): boolean {
-    return left.toUpperCase() === right.toUpperCase();
 }


### PR DESCRIPTION
# Background

Octopus Feature Flags are moving from a single form-based configuration to rules-based evaluation.

New API endpoints have been added to the Feature Flags service with a `v4` designation.

Existing form-based Feature Flags evaluations are live translated so that the provider libraries, including this one, can switch to the `v4` endpoints now and seamlessly migrate to the rules-based evaluation when it becomes available in Octopus.

# ⚠️ Breaking change

There was inconsistency between the .NET, Java and TypeScript provider libraries in regards to Segments. The .NET and Java libraries matched in a case-insensitive manner, while this library would match in a case-sensitive manner.

Included in this change is aligning the TypeScript library to be case-insensitive. This applies to matching both segment keys and values.

Note: For `v4`/rules-based feature flags, segments are now referred to as context attributes. 

# Changes

* Updated to use new `v4` endpoints, including deserialising into new rules-based evaluation types.
* Updated local storage cache so that previous cached evaluations will not be used.
  * Also increased the number of failure cases that will fall back to the cache.
  * Added tests for the local storage cache mechanism.
* Updated flag evaluation to use [new rules-based evaluation](https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/116).
* Implemented the same "only log once per missing slug" functionality as in .NET and Java provider libraries.

Resolves BMBB-754.

# Notes for review

* Some dead `v3` code has been deliberately left behind to keep PR size small. To be cleaned up in https://linear.app/octopus/issue/BMBB-781/tidy-v3-code-and-references-to-toggles-in-typescript-provider-library.
* Cache entries are referred to as `v3` which is a detached concept from feature flag schema/API versions. [In code comment](https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/119/changes#diff-84c52382bf55c6535c11cea9d20fd0e1446d2b7b856c6385cf5a76f7ec4dfb2aR17).

# Testing

* Updated to latest [specification tests](https://github.com/OctopusDeploy/openfeature-provider-specification).
* We'll do full end-to-end testing of the library before publishing.

# Release Please config

BEGIN_COMMIT_OVERRIDE
feat: Add support for upcoming rules-based evaluations
feat: Increase the number of failure cases that will fall back to the local storage cache
fix!: Segment/context attribute matching should be case-insensitive
END_COMMIT_OVERRIDE